### PR TITLE
feat(ai-quant-lab): add Statsmodels Panel with comprehensive analytics

### DIFF
--- a/fincept-terminal-desktop/src-tauri/resources/scripts/Analytics/statsmodels_cli.py
+++ b/fincept-terminal-desktop/src-tauri/resources/scripts/Analytics/statsmodels_cli.py
@@ -1,0 +1,859 @@
+"""
+Statsmodels CLI - Unified Command Line Interface for Statsmodels Analytics
+Provides a unified entry point for all statsmodels functionality in Fincept Terminal.
+
+Categories:
+- Time Series: ARIMA, SARIMAX, VAR, Exponential Smoothing, STL Decomposition
+- Regression: OLS, WLS, GLS, Rolling Regression
+- GLM: Logit, Probit, Poisson, Quantile Regression
+- Statistical Tests: ADF, KPSS, Normality, Heteroscedasticity
+- Power Analysis: Sample size, Effect size calculations
+- Multivariate: PCA, Factor Analysis
+- Nonparametric: KDE, LOWESS
+"""
+
+import sys
+import os
+
+# Add the script's directory to Python path to find statsmodels_wrapper
+script_dir = os.path.dirname(os.path.abspath(__file__))
+if script_dir not in sys.path:
+    sys.path.insert(0, script_dir)
+
+import json
+import numpy as np
+import pandas as pd
+from typing import Dict, Any, List, Optional, Union
+from datetime import datetime
+from decimal import Decimal
+
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        if isinstance(obj, np.ndarray):
+            # Convert NaN/Inf to None in arrays
+            return [self._sanitize_value(x) for x in obj.tolist()]
+        if isinstance(obj, pd.Series):
+            return [self._sanitize_value(x) for x in obj.tolist()]
+        if isinstance(obj, pd.DataFrame):
+            return obj.to_dict('records')
+        if isinstance(obj, (np.int64, np.int32)):
+            return int(obj)
+        if isinstance(obj, (np.float64, np.float32)):
+            return self._sanitize_value(float(obj))
+        if pd.isna(obj):
+            return None
+        return super().default(obj)
+
+    def _sanitize_value(self, val):
+        """Convert NaN, Inf to None for valid JSON"""
+        if isinstance(val, float):
+            if np.isnan(val) or np.isinf(val):
+                return None
+        return val
+
+    def encode(self, obj):
+        """Override encode to handle NaN/Inf in nested structures"""
+        return super().encode(self._sanitize_obj(obj))
+
+    def _sanitize_obj(self, obj):
+        """Recursively sanitize NaN/Inf values in nested structures"""
+        if isinstance(obj, dict):
+            return {k: self._sanitize_obj(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [self._sanitize_obj(x) for x in obj]
+        elif isinstance(obj, float):
+            if np.isnan(obj) or np.isinf(obj):
+                return None
+            return obj
+        elif isinstance(obj, (np.float64, np.float32)):
+            val = float(obj)
+            if np.isnan(val) or np.isinf(val):
+                return None
+            return val
+        return obj
+
+
+class StatsmodelsEngine:
+    def __init__(self):
+        self._load_modules()
+
+    def _load_modules(self):
+        try:
+            from statsmodels_wrapper import (
+                fit_arima, forecast_arima, fit_sarimax, fit_varmax,
+                fit_autoreg, fit_exponential_smoothing, stl_decompose,
+                fit_holt, fit_simple_exp_smoothing, fit_markov_regression
+            )
+            self.ts_models = {
+                'fit_arima': fit_arima,
+                'forecast_arima': forecast_arima,
+                'fit_sarimax': fit_sarimax,
+                'fit_varmax': fit_varmax,
+                'fit_autoreg': fit_autoreg,
+                'fit_exponential_smoothing': fit_exponential_smoothing,
+                'stl_decompose': stl_decompose,
+                'fit_holt': fit_holt,
+                'fit_simple_exp_smoothing': fit_simple_exp_smoothing,
+                'fit_markov_regression': fit_markov_regression
+            }
+        except ImportError as e:
+            self.ts_models = {}
+
+        try:
+            from statsmodels_wrapper import (
+                calculate_acf, calculate_pacf, adf_test, kpss_test,
+                coint_test, acorr_ljungbox, seasonal_decompose_additive,
+                arma_order_select
+            )
+            self.ts_funcs = {
+                'acf': calculate_acf,
+                'pacf': calculate_pacf,
+                'adf_test': adf_test,
+                'kpss_test': kpss_test,
+                'coint_test': coint_test,
+                'ljung_box': acorr_ljungbox,
+                'seasonal_decompose': seasonal_decompose_additive,
+                'arma_order_select': arma_order_select
+            }
+        except ImportError:
+            self.ts_funcs = {}
+
+        try:
+            from statsmodels_wrapper import (
+                fit_ols, fit_wls, fit_gls, predict_ols,
+                regression_diagnostics, fit_rolling_ols
+            )
+            self.regression = {
+                'ols': fit_ols,
+                'wls': fit_wls,
+                'gls': fit_gls,
+                'predict_ols': predict_ols,
+                'diagnostics': regression_diagnostics,
+                'rolling_ols': fit_rolling_ols
+            }
+        except ImportError:
+            self.regression = {}
+
+        try:
+            from statsmodels_wrapper import (
+                fit_glm, fit_logit, predict_logit, fit_probit,
+                fit_poisson, fit_quantreg
+            )
+            self.glm = {
+                'glm': fit_glm,
+                'logit': fit_logit,
+                'predict_logit': predict_logit,
+                'probit': fit_probit,
+                'poisson': fit_poisson,
+                'quantreg': fit_quantreg
+            }
+        except ImportError:
+            self.glm = {}
+
+        try:
+            from statsmodels_wrapper import (
+                ttest_ind, ttest_1samp, ztest, anova_lm,
+                jarque_bera_test, durbin_watson_test,
+                het_breuschpagan, het_white, descr_stats
+            )
+            self.stats_tests = {
+                'ttest_ind': ttest_ind,
+                'ttest_1samp': ttest_1samp,
+                'ztest': ztest,
+                'anova': anova_lm,
+                'jarque_bera': jarque_bera_test,
+                'durbin_watson': durbin_watson_test,
+                'breusch_pagan': het_breuschpagan,
+                'white_test': het_white,
+                'descriptive': descr_stats
+            }
+        except ImportError:
+            self.stats_tests = {}
+
+        try:
+            from statsmodels_wrapper import (
+                ttest_power, ftest_power, proportion_power,
+                calculate_effect_size_cohens_d, anova_power
+            )
+            self.power = {
+                'ttest_power': ttest_power,
+                'ftest_power': ftest_power,
+                'proportion_power': proportion_power,
+                'effect_size': calculate_effect_size_cohens_d,
+                'anova_power': anova_power
+            }
+        except ImportError:
+            self.power = {}
+
+        try:
+            from statsmodels_wrapper import (
+                perform_pca, perform_factor_analysis
+            )
+            self.multivariate = {
+                'pca': perform_pca,
+                'factor_analysis': perform_factor_analysis
+            }
+        except ImportError:
+            self.multivariate = {}
+
+        try:
+            from statsmodels_wrapper import (
+                kernel_density_estimation, lowess_smoothing
+            )
+            self.nonparametric = {
+                'kde': kernel_density_estimation,
+                'lowess': lowess_smoothing
+            }
+        except ImportError:
+            self.nonparametric = {}
+
+    def _parse_data(self, params: Dict[str, Any]) -> pd.Series:
+        data = params.get('data', [])
+        if isinstance(data, str):
+            data = [float(x.strip()) for x in data.split(',') if x.strip()]
+        if isinstance(data, dict):
+            return pd.Series(data)
+        return pd.Series(data)
+
+    def _parse_dataframe(self, params: Dict[str, Any], key: str = 'data') -> pd.DataFrame:
+        data = params.get(key, {})
+        if isinstance(data, str):
+            data = json.loads(data)
+        return pd.DataFrame(data)
+
+    def fit_arima(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'fit_arima' not in self.ts_models:
+            return {"error": "ARIMA module not available"}
+
+        data = self._parse_data(params)
+        order = params.get('order', [1, 0, 0])
+        if isinstance(order, str):
+            order = json.loads(order)
+        order = tuple(order)
+
+        result = self.ts_models['fit_arima'](data, order=order)
+        return {
+            "success": True,
+            "analysis_type": "arima",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def forecast_arima(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'forecast_arima' not in self.ts_models:
+            return {"error": "ARIMA forecasting module not available"}
+
+        data = self._parse_data(params)
+        order = params.get('order', [1, 0, 0])
+        if isinstance(order, str):
+            order = json.loads(order)
+        order = tuple(order)
+        steps = int(params.get('steps', 10))
+
+        result = self.ts_models['forecast_arima'](data, order=order, steps=steps)
+        return {
+            "success": True,
+            "analysis_type": "arima_forecast",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def fit_sarimax(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'fit_sarimax' not in self.ts_models:
+            return {"error": "SARIMAX module not available"}
+
+        data = self._parse_data(params)
+        order = params.get('order', [1, 0, 0])
+        if isinstance(order, str):
+            order = json.loads(order)
+        order = tuple(order)
+
+        seasonal_order = params.get('seasonal_order', [0, 0, 0, 12])
+        if isinstance(seasonal_order, str):
+            seasonal_order = json.loads(seasonal_order)
+        seasonal_order = tuple(seasonal_order)
+
+        result = self.ts_models['fit_sarimax'](data, order=order, seasonal_order=seasonal_order)
+        return {
+            "success": True,
+            "analysis_type": "sarimax",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def fit_exponential_smoothing(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'fit_exponential_smoothing' not in self.ts_models:
+            return {"error": "Exponential smoothing module not available"}
+
+        data = self._parse_data(params)
+        trend = params.get('trend', None)
+        seasonal = params.get('seasonal', None)
+        seasonal_periods = params.get('seasonal_periods', None)
+        if seasonal_periods:
+            seasonal_periods = int(seasonal_periods)
+
+        result = self.ts_models['fit_exponential_smoothing'](
+            data, trend=trend, seasonal=seasonal, seasonal_periods=seasonal_periods
+        )
+        return {
+            "success": True,
+            "analysis_type": "exponential_smoothing",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def stl_decompose(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'stl_decompose' not in self.ts_models:
+            return {"error": "STL decomposition module not available"}
+
+        data = self._parse_data(params)
+        period = int(params.get('period', 12))
+        seasonal = int(params.get('seasonal', 7))
+
+        result = self.ts_models['stl_decompose'](data, period=period, seasonal=seasonal)
+        return {
+            "success": True,
+            "analysis_type": "stl_decomposition",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def adf_test(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'adf_test' not in self.ts_funcs:
+            return {"error": "ADF test module not available"}
+
+        data = self._parse_data(params)
+        result = self.ts_funcs['adf_test'](data)
+        return {
+            "success": True,
+            "analysis_type": "adf_test",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def kpss_test(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'kpss_test' not in self.ts_funcs:
+            return {"error": "KPSS test module not available"}
+
+        data = self._parse_data(params)
+        result = self.ts_funcs['kpss_test'](data)
+        return {
+            "success": True,
+            "analysis_type": "kpss_test",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def calculate_acf(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'acf' not in self.ts_funcs:
+            return {"error": "ACF module not available"}
+
+        data = self._parse_data(params)
+        nlags = int(params.get('nlags', 40))
+        result = self.ts_funcs['acf'](data, nlags=nlags)
+        return {
+            "success": True,
+            "analysis_type": "acf",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def calculate_pacf(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'pacf' not in self.ts_funcs:
+            return {"error": "PACF module not available"}
+
+        data = self._parse_data(params)
+        nlags = int(params.get('nlags', 40))
+        result = self.ts_funcs['pacf'](data, nlags=nlags)
+        return {
+            "success": True,
+            "analysis_type": "pacf",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def ljung_box_test(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'ljung_box' not in self.ts_funcs:
+            return {"error": "Ljung-Box test module not available"}
+
+        data = self._parse_data(params)
+        lags = int(params.get('lags', 10))
+        result = self.ts_funcs['ljung_box'](data, lags=lags)
+        return {
+            "success": True,
+            "analysis_type": "ljung_box",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def fit_ols(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'ols' not in self.regression:
+            return {"error": "OLS regression module not available"}
+
+        y = self._parse_data(params)
+        X = params.get('X', None)
+        if X is None:
+            X = np.arange(len(y)).reshape(-1, 1)
+        else:
+            if isinstance(X, str):
+                X = json.loads(X)
+            X = np.array(X)
+
+        result = self.regression['ols'](y.values, X)
+        return {
+            "success": True,
+            "analysis_type": "ols_regression",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def regression_diagnostics(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'diagnostics' not in self.regression:
+            return {"error": "Regression diagnostics module not available"}
+
+        y = self._parse_data(params)
+        X = params.get('X', None)
+        if X is None:
+            X = np.arange(len(y)).reshape(-1, 1)
+        else:
+            if isinstance(X, str):
+                X = json.loads(X)
+            X = np.array(X)
+
+        result = self.regression['diagnostics'](y.values, X)
+        return {
+            "success": True,
+            "analysis_type": "regression_diagnostics",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def fit_logit(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'logit' not in self.glm:
+            return {"error": "Logit model module not available"}
+
+        # For logit, we need both y (binary outcome) and X (predictors)
+        # If only 'data' is provided, treat it as a dataframe with y and X columns
+        # Or if 'y' and 'X' are separate, use those
+
+        X = params.get('X', None)
+        y_data = params.get('y', params.get('data', None))
+
+        if y_data is None:
+            return {"error": "Data (y) required for logit model"}
+
+        # Parse y
+        if isinstance(y_data, str):
+            try:
+                y_data = json.loads(y_data)
+            except json.JSONDecodeError:
+                y_data = [float(x.strip()) for x in y_data.split(',') if x.strip()]
+        y = np.array(y_data) if isinstance(y_data, list) else np.array(y_data)
+
+        # Logit requires binary outcomes in [0, 1] range
+        # Convert non-binary data to binary if needed
+        unique_vals = np.unique(y)
+
+        if len(unique_vals) == 2:
+            # Already binary-like, convert to 0/1
+            if not (np.all(np.isin(unique_vals, [0, 1]))):
+                y = (y == unique_vals[1]).astype(float)
+        elif len(unique_vals) > 2:
+            # Convert continuous data to binary using returns
+            # Calculate returns: positive return = 1, negative = 0
+            returns = np.diff(y) / y[:-1]
+            y_binary = (returns >= 0).astype(float)
+            y = y_binary
+            # Adjust X to match the new length (one less due to diff)
+            # We'll create X after this block, so just note the conversion
+            conversion_note = f"Converted {len(unique_vals)} unique values to binary (positive/negative returns). Data length: {len(y)}"
+        else:
+            return {"error": "Data must have at least 2 values for logit analysis"}
+
+        # Parse X or create default X (must match y length after conversion)
+        X = params.get('X', None)
+        if X is None:
+            # If no X provided, create a simple trend predictor
+            X = np.arange(len(y)).reshape(-1, 1)
+        else:
+            if isinstance(X, str):
+                try:
+                    X = json.loads(X)
+                except json.JSONDecodeError:
+                    X = [[float(x.strip())] for x in X.split(',') if x.strip()]
+            X = np.array(X)
+
+        result = self.glm['logit'](y, X)
+        response = {
+            "success": True,
+            "analysis_type": "logit",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+        # Add conversion note if data was converted
+        if 'conversion_note' in dir() and conversion_note:
+            response["note"] = conversion_note
+            response["data_info"] = {
+                "original_unique_values": int(len(unique_vals)),
+                "binary_samples": int(len(y)),
+                "positive_returns": int(np.sum(y)),
+                "negative_returns": int(len(y) - np.sum(y))
+            }
+
+        return response
+
+    def fit_glm(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Fit Generalized Linear Model with automatic family selection"""
+        if 'glm' not in self.glm:
+            return {"error": "GLM module not available"}
+
+        # Parse y data
+        y_data = params.get('y', params.get('data', None))
+        if y_data is None:
+            return {"error": "Data (y) required for GLM model"}
+
+        if isinstance(y_data, str):
+            try:
+                y_data = json.loads(y_data)
+            except json.JSONDecodeError:
+                y_data = [float(x.strip()) for x in y_data.split(',') if x.strip()]
+        y = np.array(y_data) if isinstance(y_data, list) else np.array(y_data)
+
+        # Parse X or create default X
+        X = params.get('X', None)
+        if X is None:
+            X = np.arange(len(y)).reshape(-1, 1)
+        else:
+            if isinstance(X, str):
+                try:
+                    X = json.loads(X)
+                except json.JSONDecodeError:
+                    X = [[float(x.strip())] for x in X.split(',') if x.strip()]
+            X = np.array(X)
+
+        # Get family type - default to gaussian
+        family = params.get('family', 'gaussian').lower()
+
+        # Validate data for binomial family
+        if family == 'binomial':
+            # Ensure data is in [0, 1] range for binomial
+            if np.any(y < 0) or np.any(y > 1):
+                # Try to convert to binary (0/1)
+                unique_vals = np.unique(y)
+                if len(unique_vals) == 2:
+                    y = (y == unique_vals[1]).astype(float)
+                else:
+                    return {"error": "For binomial family, y must be binary (0/1) or proportions in [0, 1]"}
+
+        result = self.glm['glm'](y, X, family=family)
+        return {
+            "success": True,
+            "analysis_type": "glm",
+            "family": family,
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def ttest_independent(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'ttest_ind' not in self.stats_tests:
+            return {"error": "T-test module not available"}
+
+        sample1 = params.get('sample1', [])
+        sample2 = params.get('sample2', [])
+        if isinstance(sample1, str):
+            sample1 = [float(x.strip()) for x in sample1.split(',')]
+        if isinstance(sample2, str):
+            sample2 = [float(x.strip()) for x in sample2.split(',')]
+
+        result = self.stats_tests['ttest_ind'](sample1, sample2)
+        return {
+            "success": True,
+            "analysis_type": "ttest_independent",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def ttest_one_sample(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'ttest_1samp' not in self.stats_tests:
+            return {"error": "T-test module not available"}
+
+        data = self._parse_data(params)
+        popmean = float(params.get('popmean', 0))
+
+        result = self.stats_tests['ttest_1samp'](data.values, popmean)
+        return {
+            "success": True,
+            "analysis_type": "ttest_one_sample",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def jarque_bera(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'jarque_bera' not in self.stats_tests:
+            return {"error": "Jarque-Bera test module not available"}
+
+        data = self._parse_data(params)
+        result = self.stats_tests['jarque_bera'](data.values)
+        return {
+            "success": True,
+            "analysis_type": "jarque_bera",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def descriptive_stats(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'descriptive' not in self.stats_tests:
+            return {"error": "Descriptive statistics module not available"}
+
+        data = self._parse_data(params)
+        result = self.stats_tests['descriptive'](data.values)
+        return {
+            "success": True,
+            "analysis_type": "descriptive_statistics",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def ttest_power(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'ttest_power' not in self.power:
+            return {"error": "Power analysis module not available"}
+
+        effect_size = float(params.get('effect_size', 0.5))
+        alpha = float(params.get('alpha', 0.05))
+        alternative = params.get('alternative', 'two-sided')
+
+        # Get power and nobs - exactly one must be None for solve_power to work
+        power_val = params.get('power', None)
+        nobs_val = params.get('nobs', None)
+
+        # Convert to proper types if provided
+        if power_val is not None and power_val != '' and power_val != 'null':
+            power_val = float(power_val)
+        else:
+            power_val = None
+
+        if nobs_val is not None and nobs_val != '' and nobs_val != 'null':
+            nobs_val = int(nobs_val)
+        else:
+            nobs_val = None
+
+        # If both are None, default to calculating power with nobs=50
+        if power_val is None and nobs_val is None:
+            nobs_val = 50
+        # If both are provided, calculate power (ignore provided power)
+        elif power_val is not None and nobs_val is not None:
+            power_val = None
+
+        result = self.power['ttest_power'](
+            effect_size=effect_size, alpha=alpha, power=power_val, nobs=nobs_val,
+            alternative=alternative
+        )
+        return {
+            "success": True,
+            "analysis_type": "ttest_power",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def perform_pca(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'pca' not in self.multivariate:
+            return {"error": "PCA module not available"}
+
+        data = self._parse_dataframe(params)
+        # The wrapper function uses 'ncomp' not 'n_components'
+        ncomp = params.get('n_components', params.get('ncomp', 2))
+        if ncomp is not None:
+            ncomp = int(ncomp)
+        standardize = params.get('standardize', True)
+
+        result = self.multivariate['pca'](data, ncomp=ncomp, standardize=standardize)
+        return {
+            "success": True,
+            "analysis_type": "pca",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def kernel_density(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'kde' not in self.nonparametric:
+            return {"error": "KDE module not available"}
+
+        data = self._parse_data(params)
+        result = self.nonparametric['kde'](data.values)
+        return {
+            "success": True,
+            "analysis_type": "kernel_density",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def lowess_smooth(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        if 'lowess' not in self.nonparametric:
+            return {"error": "LOWESS module not available"}
+
+        y = self._parse_data(params)
+        x = params.get('x', None)
+        if x is None:
+            x = np.arange(len(y))
+        else:
+            if isinstance(x, str):
+                x = [float(v.strip()) for v in x.split(',')]
+            x = np.array(x)
+
+        frac = float(params.get('frac', 0.3))
+        result = self.nonparametric['lowess'](y.values, x, frac=frac)
+        return {
+            "success": True,
+            "analysis_type": "lowess",
+            "result": result,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def get_available_analyses(self) -> Dict[str, Any]:
+        analyses = {
+            "time_series": {
+                "arima": "Fit ARIMA model",
+                "arima_forecast": "ARIMA forecasting",
+                "sarimax": "Seasonal ARIMA with exogenous variables",
+                "exponential_smoothing": "Exponential smoothing models",
+                "stl_decompose": "STL seasonal decomposition",
+                "holt": "Holt exponential smoothing",
+                "autoreg": "Autoregressive model"
+            },
+            "stationarity_tests": {
+                "adf_test": "Augmented Dickey-Fuller test",
+                "kpss_test": "KPSS stationarity test",
+                "acf": "Autocorrelation function",
+                "pacf": "Partial autocorrelation function",
+                "ljung_box": "Ljung-Box test for autocorrelation"
+            },
+            "regression": {
+                "ols": "Ordinary Least Squares regression",
+                "wls": "Weighted Least Squares",
+                "gls": "Generalized Least Squares",
+                "rolling_ols": "Rolling window OLS",
+                "diagnostics": "Regression diagnostics"
+            },
+            "glm": {
+                "logit": "Logistic regression",
+                "probit": "Probit regression",
+                "poisson": "Poisson regression",
+                "quantreg": "Quantile regression"
+            },
+            "statistical_tests": {
+                "ttest_ind": "Independent samples t-test",
+                "ttest_1samp": "One-sample t-test",
+                "jarque_bera": "Jarque-Bera normality test",
+                "descriptive": "Descriptive statistics"
+            },
+            "power_analysis": {
+                "ttest_power": "T-test power analysis",
+                "ftest_power": "F-test power analysis",
+                "effect_size": "Effect size calculation"
+            },
+            "multivariate": {
+                "pca": "Principal Component Analysis",
+                "factor_analysis": "Factor Analysis"
+            },
+            "nonparametric": {
+                "kde": "Kernel Density Estimation",
+                "lowess": "LOWESS smoothing"
+            }
+        }
+        return {
+            "success": True,
+            "available_analyses": analyses,
+            "timestamp": datetime.now().isoformat()
+        }
+
+    def execute(self, command: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        command_map = {
+            "list": self.get_available_analyses,
+            "arima": self.fit_arima,
+            "arima_forecast": self.forecast_arima,
+            "sarimax": self.fit_sarimax,
+            "exponential_smoothing": self.fit_exponential_smoothing,
+            "stl_decompose": self.stl_decompose,
+            "adf_test": self.adf_test,
+            "kpss_test": self.kpss_test,
+            "acf": self.calculate_acf,
+            "pacf": self.calculate_pacf,
+            "ljung_box": self.ljung_box_test,
+            "ols": self.fit_ols,
+            "regression_diagnostics": self.regression_diagnostics,
+            "logit": self.fit_logit,
+            "glm": self.fit_glm,
+            "ttest_ind": self.ttest_independent,
+            "ttest_1samp": self.ttest_one_sample,
+            "jarque_bera": self.jarque_bera,
+            "descriptive": self.descriptive_stats,
+            "ttest_power": self.ttest_power,
+            "pca": self.perform_pca,
+            "kde": self.kernel_density,
+            "lowess": self.lowess_smooth
+        }
+
+        if command == "list":
+            return command_map["list"]()
+
+        handler = command_map.get(command)
+        if not handler:
+            return {
+                "error": f"Unknown command: {command}",
+                "available_commands": list(command_map.keys())
+            }
+
+        try:
+            return handler(params)
+        except Exception as e:
+            import traceback
+            return {
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+                "command": command,
+                "timestamp": datetime.now().isoformat()
+            }
+
+
+def main(args: List[str] = None) -> str:
+    if args is None:
+        args = sys.argv[1:]
+
+    if len(args) < 1:
+        result = {
+            "error": "No command provided",
+            "usage": "statsmodels_cli.py <command> [params_json]",
+            "available_commands": [
+                "list", "arima", "arima_forecast", "sarimax",
+                "exponential_smoothing", "stl_decompose", "adf_test",
+                "kpss_test", "acf", "pacf", "ljung_box", "ols",
+                "regression_diagnostics", "logit", "ttest_ind",
+                "ttest_1samp", "jarque_bera", "descriptive",
+                "ttest_power", "pca", "kde", "lowess"
+            ]
+        }
+        return json.dumps(result, cls=DecimalEncoder)
+
+    command = args[0]
+    params = {}
+
+    if len(args) > 1:
+        try:
+            params = json.loads(args[1])
+        except json.JSONDecodeError:
+            params = {"raw_input": args[1]}
+
+    engine = StatsmodelsEngine()
+    result = engine.execute(command, params)
+
+    return json.dumps(result, cls=DecimalEncoder)
+
+
+if __name__ == "__main__":
+    print(main())

--- a/fincept-terminal-desktop/src-tauri/resources/scripts/Analytics/statsmodels_wrapper/__init__.py
+++ b/fincept-terminal-desktop/src-tauri/resources/scripts/Analytics/statsmodels_wrapper/__init__.py
@@ -74,10 +74,8 @@ from .glm import (
     fit_gee,
     fit_zero_inflated_poisson,
     fit_conditional_logit,
-    fit_conditional_mnlogit,
     fit_conditional_poisson,
     fit_generalized_poisson,
-    fit_zero_inflated_negative_binomial,
     fit_zero_inflated_generalized_poisson
 )
 
@@ -166,9 +164,8 @@ __all__ = [
     # GLM models
     'fit_glm', 'fit_logit', 'predict_logit', 'fit_probit', 'fit_poisson', 'fit_negative_binomial',
     'fit_mnlogit', 'fit_quantreg', 'fit_gee', 'fit_zero_inflated_poisson',
-    'fit_conditional_logit', 'fit_conditional_mnlogit', 'fit_conditional_poisson',
-    'fit_generalized_poisson', 'fit_zero_inflated_negative_binomial',
-    'fit_zero_inflated_generalized_poisson',
+    'fit_conditional_logit', 'fit_conditional_poisson',
+    'fit_generalized_poisson', 'fit_zero_inflated_generalized_poisson',
     # Statistical tests
     'ttest_ind', 'ttest_1samp', 'ztest', 'anova_lm', 'proportions_ztest', 'proportion_confint',
     'chisquare_test', 'jarque_bera_test', 'omnibus_normtest', 'durbin_watson_test',

--- a/fincept-terminal-desktop/src-tauri/src/commands/analytics.rs
+++ b/fincept-terminal-desktop/src-tauri/src/commands/analytics.rs
@@ -496,3 +496,39 @@ pub async fn calculate_rates(
     let script_path = get_script_path(&app, "Analytics/quant/rate_calculations.py")?;
     python_runtime::execute_python_script(&script_path, args)
 }
+
+#[tauri::command]
+pub async fn execute_economics_analytics(
+    app: tauri::AppHandle,
+    command: String,
+    params: Option<String>,
+    config: Option<String>,
+) -> Result<String, String> {
+    let mut args = vec![command];
+    if let Some(p) = params {
+        args.push(p);
+    }
+    if let Some(c) = config {
+        args.push(c);
+    }
+    let script_path = get_script_path(&app, "Analytics/economics_wrapper.py")?;
+    python_runtime::execute_python_script(&script_path, args)
+}
+
+#[tauri::command]
+pub async fn execute_statsmodels_analytics(
+    app: tauri::AppHandle,
+    command: String,
+    params: Option<String>,
+) -> Result<String, String> {
+    let mut args = vec![command];
+    if let Some(p) = params {
+        args.push(p);
+    }
+    crate::utils::python::execute_python_subprocess(
+        &app,
+        "Analytics/statsmodels_cli.py",
+        &args,
+        Some("statsmodels")
+    )
+}

--- a/fincept-terminal-desktop/src-tauri/src/lib.rs
+++ b/fincept-terminal-desktop/src-tauri/src/lib.rs
@@ -1493,6 +1493,8 @@ pub fn run() {
             commands::analytics::analyze_etf,
             commands::analytics::calculate_quant_metrics,
             commands::analytics::calculate_rates,
+            commands::analytics::execute_economics_analytics,
+            commands::analytics::execute_statsmodels_analytics,
             // FinancePy - Derivatives Pricing Commands
             commands::financepy::financepy_create_date,
             commands::financepy::financepy_date_range,

--- a/fincept-terminal-desktop/src/components/tabs/ai-quant-lab/AIQuantLabTab.tsx
+++ b/fincept-terminal-desktop/src/components/tabs/ai-quant-lab/AIQuantLabTab.tsx
@@ -19,7 +19,8 @@ import {
   Activity,
   Sparkles,
   CheckCircle2,
-  Clock
+  Clock,
+  Sigma
 } from 'lucide-react';
 import { TabFooter } from '@/components/common/TabFooter';
 import { qlibService } from '@/services/aiQuantLab/qlibService';
@@ -33,6 +34,7 @@ import { LiveSignalsPanel } from './LiveSignalsPanel';
 import { FFNAnalyticsPanel } from './FFNAnalyticsPanel';
 import { FunctimePanel } from './FunctimePanel';
 import { FortitudoPanel } from './FortitudoPanel';
+import { StatsmodelsPanel } from './StatsmodelsPanel';
 import { StatusBar } from './StatusBar';
 
 // Bloomberg Professional Color Palette - Consistent across all tabs
@@ -54,7 +56,7 @@ const BLOOMBERG = {
   MUTED: '#4A4A4A'
 };
 
-type ViewMode = 'factor_discovery' | 'model_library' | 'backtesting' | 'live_signals' | 'ffn_analytics' | 'functime' | 'fortitudo';
+type ViewMode = 'factor_discovery' | 'model_library' | 'backtesting' | 'live_signals' | 'ffn_analytics' | 'functime' | 'fortitudo' | 'statsmodels';
 
 export default function AIQuantLabTab() {
   // State
@@ -158,7 +160,8 @@ export default function AIQuantLabTab() {
     { id: 'live_signals', label: 'LIVE SIGNALS', icon: Activity, description: 'Real-time predictions' },
     { id: 'ffn_analytics', label: 'FFN ANALYTICS', icon: TrendingUp, description: 'Portfolio performance & risk metrics' },
     { id: 'functime', label: 'FUNCTIME', icon: Zap, description: 'ML time series forecasting' },
-    { id: 'fortitudo', label: 'FORTITUDO', icon: Database, description: 'VaR, CVaR, option pricing, entropy pooling' }
+    { id: 'fortitudo', label: 'FORTITUDO', icon: Database, description: 'VaR, CVaR, option pricing, entropy pooling' },
+    { id: 'statsmodels', label: 'STATSMODELS', icon: Sigma, description: 'ARIMA, regression, statistical tests, PCA' }
   ];
 
   return (
@@ -284,6 +287,7 @@ export default function AIQuantLabTab() {
         {activeView === 'ffn_analytics' && <FFNAnalyticsPanel />}
         {activeView === 'functime' && <FunctimePanel />}
         {activeView === 'fortitudo' && <FortitudoPanel />}
+        {activeView === 'statsmodels' && <StatsmodelsPanel />}
       </div>
 
       {/* Status Bar */}

--- a/fincept-terminal-desktop/src/components/tabs/ai-quant-lab/StatsmodelsPanel.tsx
+++ b/fincept-terminal-desktop/src/components/tabs/ai-quant-lab/StatsmodelsPanel.tsx
@@ -1,0 +1,798 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  Activity,
+  TrendingUp,
+  BarChart2,
+  Calculator,
+  RefreshCw,
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  LineChart,
+  Percent,
+  Search,
+  Play,
+  Download,
+  Database,
+  Layers,
+  GitBranch,
+  Sigma,
+  Eye,
+  Copy
+} from 'lucide-react';
+import { statsmodelsService, type StatsmodelsResult } from '@/services/aiQuantLab/statsmodelsService';
+import { yfinanceService } from '@/services/yfinanceService';
+
+const BLOOMBERG = {
+  ORANGE: '#FF8800',
+  WHITE: '#FFFFFF',
+  RED: '#FF3B3B',
+  GREEN: '#00D66F',
+  GRAY: '#787878',
+  DARK_BG: '#000000',
+  PANEL_BG: '#0F0F0F',
+  HEADER_BG: '#1A1A1A',
+  CYAN: '#00E5FF',
+  YELLOW: '#FFD700',
+  BLUE: '#0088FF',
+  PURPLE: '#9D4EDD',
+  BORDER: '#2A2A2A',
+  HOVER: '#1F1F1F',
+  MUTED: '#4A4A4A'
+};
+
+type AnalysisCategory = 'time_series' | 'stationarity' | 'regression' | 'glm' | 'tests' | 'power' | 'multivariate' | 'nonparametric';
+type DataSourceType = 'manual' | 'symbol';
+
+interface AnalysisType {
+  id: string;
+  name: string;
+  description: string;
+  category: AnalysisCategory;
+}
+
+const analysisTypes: AnalysisType[] = [
+  { id: 'arima', name: 'ARIMA', description: 'Autoregressive Integrated Moving Average', category: 'time_series' },
+  { id: 'arima_forecast', name: 'ARIMA Forecast', description: 'Forecast with ARIMA model', category: 'time_series' },
+  { id: 'sarimax', name: 'SARIMAX', description: 'Seasonal ARIMA with exogenous variables', category: 'time_series' },
+  { id: 'exponential_smoothing', name: 'Exp Smoothing', description: 'Holt-Winters exponential smoothing', category: 'time_series' },
+  { id: 'stl_decompose', name: 'STL Decompose', description: 'Seasonal-Trend decomposition', category: 'time_series' },
+  { id: 'adf_test', name: 'ADF Test', description: 'Augmented Dickey-Fuller stationarity test', category: 'stationarity' },
+  { id: 'kpss_test', name: 'KPSS Test', description: 'KPSS stationarity test', category: 'stationarity' },
+  { id: 'acf', name: 'ACF', description: 'Autocorrelation function', category: 'stationarity' },
+  { id: 'pacf', name: 'PACF', description: 'Partial autocorrelation function', category: 'stationarity' },
+  { id: 'ljung_box', name: 'Ljung-Box', description: 'Test for autocorrelation', category: 'stationarity' },
+  { id: 'ols', name: 'OLS', description: 'Ordinary Least Squares regression', category: 'regression' },
+  { id: 'regression_diagnostics', name: 'Diagnostics', description: 'Regression diagnostics', category: 'regression' },
+  { id: 'logit', name: 'Logit', description: 'Logistic regression', category: 'glm' },
+  { id: 'ttest_ind', name: 'T-Test (Ind)', description: 'Independent samples t-test', category: 'tests' },
+  { id: 'ttest_1samp', name: 'T-Test (1 Sample)', description: 'One-sample t-test', category: 'tests' },
+  { id: 'jarque_bera', name: 'Jarque-Bera', description: 'Normality test', category: 'tests' },
+  { id: 'descriptive', name: 'Descriptive Stats', description: 'Descriptive statistics', category: 'tests' },
+  { id: 'ttest_power', name: 'T-Test Power', description: 'Power analysis for t-test', category: 'power' },
+  { id: 'pca', name: 'PCA', description: 'Principal Component Analysis', category: 'multivariate' },
+  { id: 'kde', name: 'KDE', description: 'Kernel Density Estimation', category: 'nonparametric' },
+  { id: 'lowess', name: 'LOWESS', description: 'Locally weighted regression', category: 'nonparametric' },
+];
+
+const categoryLabels: Record<AnalysisCategory, { label: string; icon: React.ElementType }> = {
+  time_series: { label: 'Time Series', icon: TrendingUp },
+  stationarity: { label: 'Stationarity Tests', icon: Activity },
+  regression: { label: 'Regression', icon: LineChart },
+  glm: { label: 'GLM Models', icon: GitBranch },
+  tests: { label: 'Statistical Tests', icon: Calculator },
+  power: { label: 'Power Analysis', icon: Percent },
+  multivariate: { label: 'Multivariate', icon: Layers },
+  nonparametric: { label: 'Nonparametric', icon: Sigma },
+};
+
+interface ParamField {
+  key: string;
+  label: string;
+  placeholder: string;
+  type: 'text' | 'number' | 'select';
+  options?: { value: string; label: string }[];
+}
+
+const getParamFields = (analysisId: string): ParamField[] => {
+  const paramMap: Record<string, ParamField[]> = {
+    arima: [
+      { key: 'order', label: 'Order (p,d,q)', placeholder: '[1,1,1]', type: 'text' },
+    ],
+    arima_forecast: [
+      { key: 'order', label: 'Order (p,d,q)', placeholder: '[1,1,1]', type: 'text' },
+      { key: 'steps', label: 'Forecast Steps', placeholder: '10', type: 'number' },
+    ],
+    sarimax: [
+      { key: 'order', label: 'Order (p,d,q)', placeholder: '[1,1,1]', type: 'text' },
+      { key: 'seasonal_order', label: 'Seasonal (P,D,Q,s)', placeholder: '[1,1,1,12]', type: 'text' },
+    ],
+    exponential_smoothing: [
+      { key: 'trend', label: 'Trend', placeholder: 'add', type: 'select', options: [{ value: '', label: 'None' }, { value: 'add', label: 'Additive' }, { value: 'mul', label: 'Multiplicative' }] },
+      { key: 'seasonal', label: 'Seasonal', placeholder: 'add', type: 'select', options: [{ value: '', label: 'None' }, { value: 'add', label: 'Additive' }, { value: 'mul', label: 'Multiplicative' }] },
+      { key: 'seasonal_periods', label: 'Seasonal Periods', placeholder: '12', type: 'number' },
+    ],
+    stl_decompose: [
+      { key: 'period', label: 'Period', placeholder: '12', type: 'number' },
+      { key: 'seasonal', label: 'Seasonal Window', placeholder: '7', type: 'number' },
+    ],
+    acf: [
+      { key: 'nlags', label: 'Number of Lags', placeholder: '40', type: 'number' },
+    ],
+    pacf: [
+      { key: 'nlags', label: 'Number of Lags', placeholder: '40', type: 'number' },
+    ],
+    ljung_box: [
+      { key: 'lags', label: 'Lags', placeholder: '10', type: 'number' },
+    ],
+    ttest_1samp: [
+      { key: 'popmean', label: 'Population Mean', placeholder: '0', type: 'number' },
+    ],
+    ttest_power: [
+      { key: 'effect_size', label: 'Effect Size', placeholder: '0.5', type: 'number' },
+      { key: 'alpha', label: 'Alpha', placeholder: '0.05', type: 'number' },
+      { key: 'power', label: 'Power (optional)', placeholder: '0.8', type: 'number' },
+      { key: 'nobs', label: 'Sample Size (optional)', placeholder: '', type: 'number' },
+    ],
+    pca: [
+      { key: 'n_components', label: 'Components', placeholder: '2', type: 'number' },
+    ],
+    lowess: [
+      { key: 'frac', label: 'Fraction', placeholder: '0.3', type: 'number' },
+    ],
+  };
+  return paramMap[analysisId] || [];
+};
+
+export function StatsmodelsPanel() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [analysisResult, setAnalysisResult] = useState<StatsmodelsResult | null>(null);
+
+  const [dataSourceType, setDataSourceType] = useState<DataSourceType>('symbol');
+  const [symbolInput, setSymbolInput] = useState('AAPL');
+  const [historicalDays, setHistoricalDays] = useState(365);
+  const [manualData, setManualData] = useState('100, 102, 101, 105, 103, 108, 107, 112, 110, 115');
+  const [priceData, setPriceData] = useState<number[]>([]);
+  const [priceDataLoading, setPriceDataLoading] = useState(false);
+
+  const [selectedCategory, setSelectedCategory] = useState<AnalysisCategory>('time_series');
+  const [selectedAnalysis, setSelectedAnalysis] = useState<string>('arima');
+  const [analysisParams, setAnalysisParams] = useState<Record<string, string>>({});
+  const [expandedArrays, setExpandedArrays] = useState<Set<string>>(new Set());
+
+  const fetchSymbolData = useCallback(async () => {
+    if (!symbolInput.trim()) return;
+
+    setPriceDataLoading(true);
+    setError(null);
+
+    try {
+      const endDate = new Date();
+      const startDate = new Date();
+      startDate.setDate(startDate.getDate() - historicalDays);
+
+      const data = await yfinanceService.getHistoricalData(
+        symbolInput.toUpperCase(),
+        startDate.toISOString().split('T')[0],
+        endDate.toISOString().split('T')[0]
+      );
+
+      if (data && data.length > 0) {
+        const closes = data.map(d => d.close);
+        setPriceData(closes);
+      } else {
+        setError('No data returned for symbol');
+      }
+    } catch (err) {
+      setError(`Failed to fetch data: ${err}`);
+    } finally {
+      setPriceDataLoading(false);
+    }
+  }, [symbolInput, historicalDays]);
+
+  useEffect(() => {
+    if (dataSourceType === 'symbol' && symbolInput) {
+      fetchSymbolData();
+    }
+  }, []);
+
+  const getDataArray = (): number[] => {
+    if (dataSourceType === 'manual') {
+      return manualData.split(',').map(v => parseFloat(v.trim())).filter(v => !isNaN(v));
+    }
+    return priceData;
+  };
+
+  const runAnalysis = async () => {
+    setIsLoading(true);
+    setError(null);
+    setAnalysisResult(null);
+
+    try {
+      const data = getDataArray();
+      if (data.length === 0) {
+        setError('No data available. Please fetch symbol data or enter manual data.');
+        setIsLoading(false);
+        return;
+      }
+
+      const params: Record<string, unknown> = { data };
+
+      Object.entries(analysisParams).forEach(([key, value]) => {
+        if (value) {
+          if (key === 'order' || key === 'seasonal_order') {
+            try {
+              params[key] = JSON.parse(value);
+            } catch {
+              params[key] = value;
+            }
+          } else if (['steps', 'nlags', 'lags', 'period', 'seasonal', 'seasonal_periods', 'n_components', 'nobs'].includes(key)) {
+            params[key] = parseInt(value);
+          } else if (['popmean', 'effect_size', 'alpha', 'power', 'frac'].includes(key)) {
+            params[key] = parseFloat(value);
+          } else {
+            params[key] = value || null;
+          }
+        }
+      });
+
+      const result = await statsmodelsService.executeCustomCommand(selectedAnalysis, params);
+      setAnalysisResult(result);
+
+      if (!result.success && result.error) {
+        setError(result.error);
+      }
+    } catch (err) {
+      setError(`Analysis failed: ${err}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const formatValue = (val: unknown, key?: string): string => {
+    if (val === null || val === undefined) return 'N/A';
+    if (typeof val === 'number') {
+      if (Number.isInteger(val)) return val.toString();
+      return val.toFixed(6);
+    }
+    if (Array.isArray(val)) {
+      const isExpanded = key && expandedArrays.has(key);
+      if (val.length > 10 && !isExpanded) {
+        return `[${val.slice(0, 5).map(v => typeof v === 'number' ? v.toFixed(4) : v).join(', ')}, ... (${val.length} items)]`;
+      }
+      return `[${val.map(v => typeof v === 'number' ? v.toFixed(4) : v).join(', ')}]`;
+    }
+    return String(val);
+  };
+
+  const toggleArrayExpand = (key: string) => {
+    setExpandedArrays(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(key)) {
+        newSet.delete(key);
+      } else {
+        newSet.add(key);
+      }
+      return newSet;
+    });
+  };
+
+  const exportData = (key: string, value: unknown) => {
+    let content: string;
+    let filename: string;
+
+    if (Array.isArray(value)) {
+      // Export as CSV
+      content = value.map((v, i) => `${i},${typeof v === 'number' ? v : JSON.stringify(v)}`).join('\n');
+      content = 'index,value\n' + content;
+      filename = `${selectedAnalysis}_${key}.csv`;
+    } else {
+      // Export as JSON
+      content = JSON.stringify({ [key]: value }, null, 2);
+      filename = `${selectedAnalysis}_${key}.json`;
+    }
+
+    const blob = new Blob([content], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportAllResults = () => {
+    if (!analysisResult) return;
+    const content = JSON.stringify(analysisResult, null, 2);
+    const blob = new Blob([content], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${selectedAnalysis}_results.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const copyToClipboard = (value: unknown) => {
+    const text = Array.isArray(value)
+      ? value.map(v => typeof v === 'number' ? v.toFixed(6) : v).join('\n')
+      : JSON.stringify(value, null, 2);
+    navigator.clipboard.writeText(text);
+  };
+
+  const renderResult = () => {
+    if (!analysisResult) return null;
+
+    return (
+      <div
+        className="border rounded p-4 mt-4"
+        style={{ backgroundColor: BLOOMBERG.PANEL_BG, borderColor: BLOOMBERG.BORDER }}
+      >
+        <div className="flex items-center gap-2 mb-3">
+          {analysisResult.success ? (
+            <CheckCircle2 size={16} color={BLOOMBERG.GREEN} />
+          ) : (
+            <AlertCircle size={16} color={BLOOMBERG.RED} />
+          )}
+          <span
+            className="text-xs font-semibold"
+            style={{ color: analysisResult.success ? BLOOMBERG.GREEN : BLOOMBERG.RED }}
+          >
+            {analysisResult.success ? 'ANALYSIS COMPLETE' : 'ANALYSIS FAILED'}
+          </span>
+          {analysisResult.analysis_type && (
+            <span className="text-xs" style={{ color: BLOOMBERG.GRAY }}>
+              - {analysisResult.analysis_type.toUpperCase()}
+            </span>
+          )}
+        </div>
+
+        {analysisResult.error && (
+          <div className="text-xs p-2 rounded mb-3" style={{ backgroundColor: BLOOMBERG.DARK_BG, color: BLOOMBERG.RED }}>
+            {analysisResult.error}
+            {analysisResult.message && (
+              <div className="mt-1" style={{ color: BLOOMBERG.GRAY }}>{analysisResult.message}</div>
+            )}
+            {analysisResult.suggestions && Array.isArray(analysisResult.suggestions) && (
+              <div className="mt-2" style={{ color: BLOOMBERG.ORANGE }}>
+                <div className="font-semibold mb-1">Suggestions:</div>
+                <ul className="list-disc list-inside">
+                  {analysisResult.suggestions.map((s: string, i: number) => (
+                    <li key={i}>{s}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        )}
+
+        {analysisResult.result && (
+          <div className="space-y-2">
+            {Object.entries(analysisResult.result).map(([key, value]) => {
+              const isArray = Array.isArray(value);
+              const isLargeArray = isArray && value.length > 10;
+              const isExpanded = expandedArrays.has(key);
+
+              return (
+                <div key={key} className="py-2 border-b" style={{ borderColor: BLOOMBERG.BORDER }}>
+                  <div className="flex justify-between items-start gap-4">
+                    <span className="text-xs font-mono" style={{ color: BLOOMBERG.ORANGE }}>{key}</span>
+                    <div className="flex items-center gap-1">
+                      {isLargeArray && (
+                        <>
+                          <button
+                            onClick={() => toggleArrayExpand(key)}
+                            className="p-1 rounded hover:bg-opacity-20 hover:bg-white"
+                            title={isExpanded ? "Collapse" : "View All"}
+                          >
+                            {isExpanded ? (
+                              <ChevronUp size={12} color={BLOOMBERG.GRAY} />
+                            ) : (
+                              <Eye size={12} color={BLOOMBERG.GRAY} />
+                            )}
+                          </button>
+                          <button
+                            onClick={() => copyToClipboard(value)}
+                            className="p-1 rounded hover:bg-opacity-20 hover:bg-white"
+                            title="Copy to Clipboard"
+                          >
+                            <Copy size={12} color={BLOOMBERG.GRAY} />
+                          </button>
+                          <button
+                            onClick={() => exportData(key, value)}
+                            className="p-1 rounded hover:bg-opacity-20 hover:bg-white"
+                            title="Export as CSV"
+                          >
+                            <Download size={12} color={BLOOMBERG.GRAY} />
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div
+                    className="text-xs font-mono mt-1"
+                    style={{
+                      color: BLOOMBERG.WHITE,
+                      maxHeight: isExpanded ? '300px' : 'none',
+                      overflowY: isExpanded ? 'auto' : 'visible',
+                      wordBreak: 'break-all'
+                    }}
+                  >
+                    {formatValue(value, key)}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {analysisResult.result && (
+          <div className="mt-3 flex justify-end">
+            <button
+              onClick={exportAllResults}
+              className="flex items-center gap-1 px-3 py-1.5 text-xs font-semibold rounded"
+              style={{ backgroundColor: BLOOMBERG.HEADER_BG, color: BLOOMBERG.ORANGE, border: `1px solid ${BLOOMBERG.BORDER}` }}
+            >
+              <Download size={12} />
+              Export All Results
+            </button>
+          </div>
+        )}
+
+        {analysisResult.timestamp && (
+          <div className="mt-3 text-xs" style={{ color: BLOOMBERG.MUTED }}>
+            Timestamp: {analysisResult.timestamp}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="flex h-full" style={{ backgroundColor: BLOOMBERG.DARK_BG }}>
+      <div
+        className="w-80 flex-shrink-0 border-r overflow-y-auto"
+        style={{ backgroundColor: BLOOMBERG.PANEL_BG, borderColor: BLOOMBERG.BORDER }}
+      >
+        <div className="p-4 border-b" style={{ borderColor: BLOOMBERG.BORDER }}>
+          <div className="flex items-center gap-2 mb-3">
+            <Activity size={16} color={BLOOMBERG.ORANGE} />
+            <span className="text-xs font-bold" style={{ color: BLOOMBERG.ORANGE }}>DATA SOURCE</span>
+          </div>
+
+          <div className="flex gap-2 mb-3">
+            <button
+              onClick={() => setDataSourceType('symbol')}
+              className="flex-1 py-1.5 text-xs font-semibold rounded"
+              style={{
+                backgroundColor: dataSourceType === 'symbol' ? BLOOMBERG.ORANGE : BLOOMBERG.DARK_BG,
+                color: dataSourceType === 'symbol' ? BLOOMBERG.DARK_BG : BLOOMBERG.GRAY,
+                border: `1px solid ${BLOOMBERG.BORDER}`
+              }}
+            >
+              SYMBOL
+            </button>
+            <button
+              onClick={() => setDataSourceType('manual')}
+              className="flex-1 py-1.5 text-xs font-semibold rounded"
+              style={{
+                backgroundColor: dataSourceType === 'manual' ? BLOOMBERG.ORANGE : BLOOMBERG.DARK_BG,
+                color: dataSourceType === 'manual' ? BLOOMBERG.DARK_BG : BLOOMBERG.GRAY,
+                border: `1px solid ${BLOOMBERG.BORDER}`
+              }}
+            >
+              MANUAL
+            </button>
+          </div>
+
+          {dataSourceType === 'symbol' ? (
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={symbolInput}
+                  onChange={(e) => setSymbolInput(e.target.value.toUpperCase())}
+                  placeholder="AAPL"
+                  className="flex-1 px-2 py-1.5 text-xs font-mono rounded"
+                  style={{
+                    backgroundColor: BLOOMBERG.DARK_BG,
+                    color: BLOOMBERG.WHITE,
+                    border: `1px solid ${BLOOMBERG.BORDER}`
+                  }}
+                />
+                <button
+                  onClick={fetchSymbolData}
+                  disabled={priceDataLoading}
+                  className="px-3 py-1.5 rounded"
+                  style={{ backgroundColor: BLOOMBERG.BLUE, color: BLOOMBERG.WHITE }}
+                >
+                  {priceDataLoading ? <RefreshCw size={12} className="animate-spin" /> : <Search size={12} />}
+                </button>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-xs" style={{ color: BLOOMBERG.GRAY }}>Days:</span>
+                <select
+                  value={historicalDays}
+                  onChange={(e) => setHistoricalDays(parseInt(e.target.value))}
+                  className="flex-1 px-2 py-1 text-xs rounded"
+                  style={{
+                    backgroundColor: BLOOMBERG.DARK_BG,
+                    color: BLOOMBERG.WHITE,
+                    border: `1px solid ${BLOOMBERG.BORDER}`
+                  }}
+                >
+                  <option value={30}>30 Days</option>
+                  <option value={90}>90 Days</option>
+                  <option value={180}>180 Days</option>
+                  <option value={365}>1 Year</option>
+                  <option value={730}>2 Years</option>
+                  <option value={1825}>5 Years</option>
+                </select>
+              </div>
+              {priceData.length > 0 && (
+                <div className="text-xs" style={{ color: BLOOMBERG.GREEN }}>
+                  Loaded {priceData.length} data points
+                </div>
+              )}
+            </div>
+          ) : (
+            <textarea
+              value={manualData}
+              onChange={(e) => setManualData(e.target.value)}
+              placeholder="Enter comma-separated values..."
+              rows={4}
+              className="w-full px-2 py-1.5 text-xs font-mono rounded"
+              style={{
+                backgroundColor: BLOOMBERG.DARK_BG,
+                color: BLOOMBERG.WHITE,
+                border: `1px solid ${BLOOMBERG.BORDER}`
+              }}
+            />
+          )}
+        </div>
+
+        <div className="p-4 border-b" style={{ borderColor: BLOOMBERG.BORDER }}>
+          <div className="flex items-center gap-2 mb-3">
+            <BarChart2 size={16} color={BLOOMBERG.ORANGE} />
+            <span className="text-xs font-bold" style={{ color: BLOOMBERG.ORANGE }}>CATEGORY</span>
+          </div>
+          <select
+            value={selectedCategory}
+            onChange={(e) => {
+              const cat = e.target.value as AnalysisCategory;
+              setSelectedCategory(cat);
+              const first = analysisTypes.find(a => a.category === cat);
+              if (first) {
+                setSelectedAnalysis(first.id);
+                setAnalysisParams({});
+              }
+            }}
+            className="w-full px-2 py-1.5 text-xs rounded"
+            style={{
+              backgroundColor: BLOOMBERG.DARK_BG,
+              color: BLOOMBERG.WHITE,
+              border: `1px solid ${BLOOMBERG.BORDER}`
+            }}
+          >
+            {Object.entries(categoryLabels).map(([key, { label }]) => (
+              <option key={key} value={key}>{label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="p-4 border-b" style={{ borderColor: BLOOMBERG.BORDER }}>
+          <div className="flex items-center gap-2 mb-3">
+            <Calculator size={16} color={BLOOMBERG.ORANGE} />
+            <span className="text-xs font-bold" style={{ color: BLOOMBERG.ORANGE }}>ANALYSIS</span>
+          </div>
+          <select
+            value={selectedAnalysis}
+            onChange={(e) => {
+              setSelectedAnalysis(e.target.value);
+              setAnalysisParams({});
+            }}
+            className="w-full px-2 py-1.5 text-xs rounded"
+            style={{
+              backgroundColor: BLOOMBERG.DARK_BG,
+              color: BLOOMBERG.WHITE,
+              border: `1px solid ${BLOOMBERG.BORDER}`
+            }}
+          >
+            {analysisTypes
+              .filter(a => a.category === selectedCategory)
+              .map(a => (
+                <option key={a.id} value={a.id}>{a.name}</option>
+              ))}
+          </select>
+          <div className="mt-2 text-xs" style={{ color: BLOOMBERG.GRAY }}>
+            {analysisTypes.find(a => a.id === selectedAnalysis)?.description}
+          </div>
+          {selectedAnalysis === 'logit' && (
+            <div className="mt-2 p-2 rounded text-xs" style={{ backgroundColor: BLOOMBERG.DARK_BG, color: BLOOMBERG.ORANGE }}>
+              <strong>Note:</strong> Logit models binary outcomes (0/1). Price data will be auto-converted to returns direction (up=1, down=0).
+            </div>
+          )}
+        </div>
+
+        {getParamFields(selectedAnalysis).length > 0 && (
+          <div className="p-4 border-b" style={{ borderColor: BLOOMBERG.BORDER }}>
+            <div className="flex items-center gap-2 mb-3">
+              <ChevronDown size={16} color={BLOOMBERG.ORANGE} />
+              <span className="text-xs font-bold" style={{ color: BLOOMBERG.ORANGE }}>PARAMETERS</span>
+            </div>
+            <div className="space-y-3">
+              {getParamFields(selectedAnalysis).map(field => (
+                <div key={field.key}>
+                  <label className="text-xs block mb-1" style={{ color: BLOOMBERG.GRAY }}>{field.label}</label>
+                  {field.type === 'select' ? (
+                    <select
+                      value={analysisParams[field.key] || ''}
+                      onChange={(e) => setAnalysisParams(prev => ({ ...prev, [field.key]: e.target.value }))}
+                      className="w-full px-2 py-1.5 text-xs rounded"
+                      style={{
+                        backgroundColor: BLOOMBERG.DARK_BG,
+                        color: BLOOMBERG.WHITE,
+                        border: `1px solid ${BLOOMBERG.BORDER}`
+                      }}
+                    >
+                      {field.options?.map(opt => (
+                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                      ))}
+                    </select>
+                  ) : (
+                    <input
+                      type={field.type}
+                      value={analysisParams[field.key] || ''}
+                      onChange={(e) => setAnalysisParams(prev => ({ ...prev, [field.key]: e.target.value }))}
+                      placeholder={field.placeholder}
+                      className="w-full px-2 py-1.5 text-xs font-mono rounded"
+                      style={{
+                        backgroundColor: BLOOMBERG.DARK_BG,
+                        color: BLOOMBERG.WHITE,
+                        border: `1px solid ${BLOOMBERG.BORDER}`
+                      }}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="p-4">
+          <button
+            onClick={runAnalysis}
+            disabled={isLoading}
+            className="w-full py-2.5 text-xs font-bold rounded flex items-center justify-center gap-2"
+            style={{
+              backgroundColor: isLoading ? BLOOMBERG.MUTED : BLOOMBERG.ORANGE,
+              color: BLOOMBERG.DARK_BG
+            }}
+          >
+            {isLoading ? (
+              <>
+                <RefreshCw size={14} className="animate-spin" />
+                RUNNING...
+              </>
+            ) : (
+              <>
+                <Play size={14} />
+                RUN ANALYSIS
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="mb-6">
+          <h2 className="text-lg font-bold mb-1" style={{ color: BLOOMBERG.WHITE }}>
+            STATSMODELS ANALYTICS
+          </h2>
+          <p className="text-xs" style={{ color: BLOOMBERG.GRAY }}>
+            Statistical modeling and econometric analysis powered by statsmodels library
+          </p>
+        </div>
+
+        <div className="grid grid-cols-4 gap-3 mb-6">
+          {Object.entries(categoryLabels).map(([key, { label, icon: Icon }]) => {
+            const count = analysisTypes.filter(a => a.category === key).length;
+            const isSelected = selectedCategory === key;
+            return (
+              <button
+                key={key}
+                onClick={() => {
+                  setSelectedCategory(key as AnalysisCategory);
+                  const first = analysisTypes.find(a => a.category === key);
+                  if (first) {
+                    setSelectedAnalysis(first.id);
+                    setAnalysisParams({});
+                  }
+                }}
+                className="p-3 rounded text-left transition-all"
+                style={{
+                  backgroundColor: isSelected ? BLOOMBERG.ORANGE : BLOOMBERG.PANEL_BG,
+                  border: `1px solid ${isSelected ? BLOOMBERG.ORANGE : BLOOMBERG.BORDER}`
+                }}
+              >
+                <Icon size={16} color={isSelected ? BLOOMBERG.DARK_BG : BLOOMBERG.GRAY} />
+                <div
+                  className="text-xs font-semibold mt-2"
+                  style={{ color: isSelected ? BLOOMBERG.DARK_BG : BLOOMBERG.WHITE }}
+                >
+                  {label}
+                </div>
+                <div
+                  className="text-xs"
+                  style={{ color: isSelected ? BLOOMBERG.DARK_BG : BLOOMBERG.MUTED }}
+                >
+                  {count} analyses
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="mb-6">
+          <div className="text-xs font-bold mb-3" style={{ color: BLOOMBERG.ORANGE }}>
+            AVAILABLE IN {categoryLabels[selectedCategory].label.toUpperCase()}
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            {analysisTypes
+              .filter(a => a.category === selectedCategory)
+              .map(a => (
+                <button
+                  key={a.id}
+                  onClick={() => {
+                    setSelectedAnalysis(a.id);
+                    setAnalysisParams({});
+                  }}
+                  className="p-2.5 rounded text-left"
+                  style={{
+                    backgroundColor: selectedAnalysis === a.id ? BLOOMBERG.BLUE : BLOOMBERG.HEADER_BG,
+                    border: `1px solid ${BLOOMBERG.BORDER}`
+                  }}
+                >
+                  <div className="text-xs font-semibold" style={{ color: BLOOMBERG.WHITE }}>{a.name}</div>
+                  <div className="text-xs mt-1" style={{ color: BLOOMBERG.GRAY }}>{a.description}</div>
+                </button>
+              ))}
+          </div>
+        </div>
+
+        {error && (
+          <div
+            className="p-3 rounded mb-4 flex items-center gap-2"
+            style={{ backgroundColor: BLOOMBERG.PANEL_BG, border: `1px solid ${BLOOMBERG.RED}` }}
+          >
+            <AlertCircle size={16} color={BLOOMBERG.RED} />
+            <span className="text-xs" style={{ color: BLOOMBERG.RED }}>{error}</span>
+          </div>
+        )}
+
+        {renderResult()}
+
+        {!analysisResult && !error && (
+          <div
+            className="p-8 rounded text-center"
+            style={{ backgroundColor: BLOOMBERG.PANEL_BG, border: `1px solid ${BLOOMBERG.BORDER}` }}
+          >
+            <Database size={48} color={BLOOMBERG.MUTED} className="mx-auto mb-4" />
+            <div className="text-sm" style={{ color: BLOOMBERG.GRAY }}>
+              Select an analysis and click RUN ANALYSIS to begin
+            </div>
+            <div className="text-xs mt-2" style={{ color: BLOOMBERG.MUTED }}>
+              {getDataArray().length > 0
+                ? `${getDataArray().length} data points ready`
+                : 'No data loaded - fetch symbol data or enter manual values'}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default StatsmodelsPanel;

--- a/fincept-terminal-desktop/src/services/aiQuantLab/statsmodelsService.ts
+++ b/fincept-terminal-desktop/src/services/aiQuantLab/statsmodelsService.ts
@@ -1,0 +1,254 @@
+import { invoke } from '@tauri-apps/api/core';
+
+export interface StatsmodelsResult<T = Record<string, unknown>> {
+  success: boolean;
+  analysis_type?: string;
+  result?: T;
+  error?: string;
+  traceback?: string;
+  timestamp?: string;
+  available_commands?: string[];
+  available_analyses?: Record<string, Record<string, string>>;
+}
+
+export interface ARIMAParams {
+  data: number[] | string;
+  order?: [number, number, number];
+}
+
+export interface ARIMAForecastParams {
+  data: number[] | string;
+  order?: [number, number, number];
+  steps?: number;
+}
+
+export interface SARIMAXParams {
+  data: number[] | string;
+  order?: [number, number, number];
+  seasonal_order?: [number, number, number, number];
+}
+
+export interface ExponentialSmoothingParams {
+  data: number[] | string;
+  trend?: 'add' | 'mul' | null;
+  seasonal?: 'add' | 'mul' | null;
+  seasonal_periods?: number;
+}
+
+export interface STLDecomposeParams {
+  data: number[] | string;
+  period?: number;
+  seasonal?: number;
+}
+
+export interface StationarityTestParams {
+  data: number[] | string;
+}
+
+export interface ACFPACFParams {
+  data: number[] | string;
+  nlags?: number;
+}
+
+export interface OLSParams {
+  data: number[] | string;
+  X?: number[][] | string;
+}
+
+export interface TTestIndParams {
+  sample1: number[] | string;
+  sample2: number[] | string;
+}
+
+export interface TTestOneSampleParams {
+  data: number[] | string;
+  popmean?: number;
+}
+
+export interface PowerAnalysisParams {
+  effect_size?: number;
+  alpha?: number;
+  power?: number;
+  nobs?: number;
+}
+
+export interface PCAParams {
+  data: Record<string, number[]>;
+  n_components?: number;
+}
+
+export interface LOWESSParams {
+  data: number[] | string;
+  x?: number[] | string;
+  frac?: number;
+}
+
+export interface ARIMAResult {
+  params: number[];
+  aic: number;
+  bic: number;
+  hqic?: number;
+  resid: number[];
+  fittedvalues: number[];
+}
+
+export interface ForecastResult {
+  forecast: number[];
+  aic: number;
+  bic: number;
+}
+
+export interface STLResult {
+  trend: number[];
+  seasonal: number[];
+  resid: number[];
+}
+
+export interface StationarityResult {
+  statistic: number;
+  pvalue: number;
+  critical_values?: Record<string, number>;
+  is_stationary?: boolean;
+}
+
+export interface RegressionResult {
+  params: number[];
+  rsquared: number;
+  rsquared_adj?: number;
+  fvalue?: number;
+  f_pvalue?: number;
+  aic?: number;
+  bic?: number;
+  resid?: number[];
+}
+
+export interface DescriptiveResult {
+  mean: number;
+  std: number;
+  min: number;
+  max: number;
+  median?: number;
+  skewness?: number;
+  kurtosis?: number;
+  nobs: number;
+}
+
+async function executeStatsmodels<T>(
+  command: string,
+  params?: Record<string, unknown>
+): Promise<StatsmodelsResult<T>> {
+  try {
+    const paramsJson = params ? JSON.stringify(params) : undefined;
+
+    const result = await invoke<string>('execute_statsmodels_analytics', {
+      command,
+      params: paramsJson,
+    });
+
+    return JSON.parse(result) as StatsmodelsResult<T>;
+  } catch (error) {
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export const statsmodelsService = {
+  listAvailableAnalyses(): Promise<StatsmodelsResult> {
+    return executeStatsmodels('list');
+  },
+
+  fitARIMA(params: ARIMAParams): Promise<StatsmodelsResult<ARIMAResult>> {
+    return executeStatsmodels('arima', params);
+  },
+
+  forecastARIMA(params: ARIMAForecastParams): Promise<StatsmodelsResult<ForecastResult>> {
+    return executeStatsmodels('arima_forecast', params);
+  },
+
+  fitSARIMAX(params: SARIMAXParams): Promise<StatsmodelsResult<ARIMAResult>> {
+    return executeStatsmodels('sarimax', params);
+  },
+
+  fitExponentialSmoothing(params: ExponentialSmoothingParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('exponential_smoothing', params);
+  },
+
+  stlDecompose(params: STLDecomposeParams): Promise<StatsmodelsResult<STLResult>> {
+    return executeStatsmodels('stl_decompose', params);
+  },
+
+  adfTest(params: StationarityTestParams): Promise<StatsmodelsResult<StationarityResult>> {
+    return executeStatsmodels('adf_test', params);
+  },
+
+  kpssTest(params: StationarityTestParams): Promise<StatsmodelsResult<StationarityResult>> {
+    return executeStatsmodels('kpss_test', params);
+  },
+
+  calculateACF(params: ACFPACFParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('acf', params);
+  },
+
+  calculatePACF(params: ACFPACFParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('pacf', params);
+  },
+
+  ljungBoxTest(params: StationarityTestParams & { lags?: number }): Promise<StatsmodelsResult> {
+    return executeStatsmodels('ljung_box', params);
+  },
+
+  fitOLS(params: OLSParams): Promise<StatsmodelsResult<RegressionResult>> {
+    return executeStatsmodels('ols', params);
+  },
+
+  regressionDiagnostics(params: OLSParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('regression_diagnostics', params);
+  },
+
+  fitLogit(params: OLSParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('logit', params);
+  },
+
+  ttestIndependent(params: TTestIndParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('ttest_ind', params);
+  },
+
+  ttestOneSample(params: TTestOneSampleParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('ttest_1samp', params);
+  },
+
+  jarqueBera(params: StationarityTestParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('jarque_bera', params);
+  },
+
+  descriptiveStats(params: StationarityTestParams): Promise<StatsmodelsResult<DescriptiveResult>> {
+    return executeStatsmodels('descriptive', params);
+  },
+
+  ttestPower(params: PowerAnalysisParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('ttest_power', params);
+  },
+
+  performPCA(params: PCAParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('pca', params);
+  },
+
+  kernelDensity(params: StationarityTestParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('kde', params);
+  },
+
+  lowessSmooth(params: LOWESSParams): Promise<StatsmodelsResult> {
+    return executeStatsmodels('lowess', params);
+  },
+
+  executeCustomCommand<T>(
+    command: string,
+    params?: Record<string, unknown>
+  ): Promise<StatsmodelsResult<T>> {
+    return executeStatsmodels<T>(command, params);
+  },
+};
+
+export default statsmodelsService;


### PR DESCRIPTION
- Add StatsmodelsPanel component with Bloomberg-style UI for statistical analysis
- Implement statsmodels_cli.py as unified CLI for all statsmodels functionality
- Add statsmodelsService.ts for frontend-backend communication
- Support time series (ARIMA, SARIMAX, STL), regression (OLS, WLS, GLS), GLM (logit, probit, poisson), statistical tests, power analysis, multivariate (PCA), and nonparametric methods (KDE, LOWESS)
- Auto-convert continuous price data to binary returns for logit models
- Handle NaN/Inf values in JSON output for robust error handling
- Add data export (CSV) and view all functionality for large result arrays
- Fix statsmodels_wrapper imports for missing functions
- Use subprocess execution for Windows reliability