### PR TITLE
fix: commodity futures empty data and crypto watchlist prices not loading

### DIFF
--- a/fincept-terminal-desktop/src-tauri/resources/scripts/yfinance_data.py
+++ b/fincept-terminal-desktop/src-tauri/resources/scripts/yfinance_data.py
@@ -15,7 +15,7 @@ def get_quote(symbol):
     try:
         ticker = yf.Ticker(symbol)
         info = ticker.info
-        hist = ticker.history(period="1d")
+        hist = ticker.history(period="5d")
 
         if hist.empty:
             return {"error": "No data available", "symbol": symbol}


### PR DESCRIPTION
## Summary

- **yfinance_data.py**: Change `period="1d"` to `period="5d"` in `get_quote()` — Yahoo Finance rejects single-day history queries for commodity futures symbols (GC=F, CL=F, SI=F, etc.), returning empty data. Using `period="5d"` and taking the last row works for all symbol types including stocks.
- **CryptoTradingTab.tsx**: Replace Binance API with CoinGecko for crypto watchlist sidebar prices — Binance REST API is blocked in the US (`Service unavailable from a restricted location`). Uses Tauri's HTTP plugin (`tauriFetch`) to bypass CORS restrictions in the webview.

## Test plan

- [x] Verify commodity futures (GC=F, CL=F, SI=F) return price data on the dashboard
- [x] Verify stock quotes (AAPL, MSFT) still work with `period="5d"`
- [x] Verify crypto watchlist sidebar on the Crypto Trading tab shows prices for all 30 symbols
- [x] Verify prices refresh every 30 seconds without errors