### PR TITLE
fix(setup): correct macOS Qt path and add missing dependencies

### DIFF
--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -154,6 +154,22 @@ if(Qt6TextToSpeech_FOUND)
     set(HAS_TTS TRUE)
 endif()
 
+# macOS 14+ / Xcode 15+ removes the AGL framework. Qt6's WrapOpenGL target (pulled in
+# by Qt6::Gui) hardcodes a fallback to `-framework AGL` if it isn't found on the system.
+# We strip it from the INTERFACE_LINK_LIBRARIES to prevent `ld: framework 'AGL' not found`.
+if(APPLE AND TARGET WrapOpenGL::WrapOpenGL)
+    get_target_property(_gl_libs WrapOpenGL::WrapOpenGL INTERFACE_LINK_LIBRARIES)
+    if(_gl_libs)
+        set(_new_gl_libs "")
+        foreach(_lib IN LISTS _gl_libs)
+            if(NOT _lib MATCHES "AGL")
+                list(APPEND _new_gl_libs "${_lib}")
+            endif()
+        endforeach()
+        set_target_properties(WrapOpenGL::WrapOpenGL PROPERTIES INTERFACE_LINK_LIBRARIES "${_new_gl_libs}")
+    endif()
+endif()
+
 # ── FetchContent dependencies ─────────────────────────────────────────────────
 # Guard: prevent all FetchContent subdirectories from registering install()
 # rules that would pollute CPack and cause "file not found" errors on packaging.

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ echo ""
 OS="$(uname -s)"
 case "$OS" in
     Linux*)  PLATFORM="linux" ; QT_KIT="gcc_64"     ; PRESET="linux-release" ;;
-    Darwin*) PLATFORM="macos" ; QT_KIT="clang_64"   ; PRESET="macos-release" ;;
+    Darwin*) PLATFORM="macos" ; QT_KIT="macos"      ; PRESET="macos-release" ;;
     *)       fail "Unsupported OS: $OS" ;;
 esac
 echo "Platform: $OS"
@@ -68,7 +68,7 @@ elif [ "$PLATFORM" = "macos" ]; then
         info "Homebrew not found. Installing..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
     fi
-    brew install cmake ninja python@3.11
+    brew install cmake ninja python@3.11 openssl@3 yt-dlp
 fi
 ok
 
@@ -148,7 +148,12 @@ cd "$APP_DIR"
 echo "[6/7] Configuring (preset: $PRESET)..."
 # Override the preset's default CMAKE_PREFIX_PATH with the one we just set,
 # so the build picks up the aqtinstall location rather than ~/Qt/6.8.3/...
-cmake --preset "$PRESET" -DCMAKE_PREFIX_PATH="$QT_PREFIX" \
+EXTRA_ARGS=""
+if [ "$PLATFORM" = "macos" ] && [ -d "/opt/homebrew/opt/openssl@3" ]; then
+    EXTRA_ARGS="-DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3"
+fi
+
+cmake --preset "$PRESET" -DCMAKE_PREFIX_PATH="$QT_PREFIX" $EXTRA_ARGS \
     || fail "CMake configure failed. See error above."
 ok
 


### PR DESCRIPTION
Resolves #167

This PR implements the fixes described in #167 to resolve macOS build and setup failures:
- Updates `QT_KIT` for Darwin from `clang_64` to `macos` to match the aqtinstall 6.8.3 layout.
- Adds `openssl@3` and `yt-dlp` to the Homebrew install list.
- Explicitly sets `OPENSSL_ROOT_DIR` for CMake on macOS to link correct arm64 libraries.