### PR TITLE
build(macos): work around Qt 6.8 FindWrapOpenGL AGL fallback on macOS 14+

### DIFF
--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -127,6 +127,27 @@ option(FINCEPT_BUILD_TESTS "Build the Fincept Terminal test suite" OFF)
 # installer. Developers may override for local experimentation with
 # -DFINCEPT_ALLOW_QT_DRIFT=ON (not for CI or release builds).
 set(FINCEPT_QT_VERSION 6.8.3)
+
+# Qt 6.8 FindWrapOpenGL.cmake hard-codes "-framework AGL" as a fallback when
+# find_library(AGL) fails. Apple removed AGL in macOS 14+ (Sonoma), causing
+# linker errors on modern SDKs. Pre-create WrapOpenGL::WrapOpenGL without AGL
+# so Qt's FindWrapOpenGL takes its early-return path (target already exists).
+if(APPLE AND NOT TARGET WrapOpenGL::WrapOpenGL)
+    find_package(OpenGL QUIET)
+    if(OpenGL_FOUND)
+        add_library(WrapOpenGL::WrapOpenGL INTERFACE IMPORTED)
+        get_target_property(_fincept_ogl_loc OpenGL::GL IMPORTED_LOCATION)
+        if(_fincept_ogl_loc AND NOT _fincept_ogl_loc MATCHES "/([^/]+)\\.framework$")
+            get_filename_component(_fincept_ogl_path "${_fincept_ogl_loc}" DIRECTORY)
+        endif()
+        if(NOT _fincept_ogl_path)
+            set(_fincept_ogl_path "-framework OpenGL")
+        endif()
+        target_link_libraries(WrapOpenGL::WrapOpenGL INTERFACE "${_fincept_ogl_path}")
+        set(WrapOpenGL_FOUND ON)
+    endif()
+endif()
+
 if(FINCEPT_ALLOW_QT_DRIFT)
     find_package(Qt6 REQUIRED COMPONENTS
         Widgets Charts PrintSupport Network Sql Concurrent Multimedia)


### PR DESCRIPTION
## What does this PR do?
Fixes `ld: framework 'AGL' not found` linker error on macOS 14+ (Sonoma) — see [#140 comment](https://github.com/Fincept-Corporation/FinceptTerminal/issues/140#issuecomment-4277521087) for the full diagnosis. Apple removed AGL in Sonoma, but Qt 6.8's `FindWrapOpenGL.cmake` hard-codes it as a fallback, breaking builds on every modern macOS SDK.

## Type of Change
- [x] Bug fix
- [x] Build / config change

## Related Issues
Fixes #140

## Changes Made
`fincept-qt/CMakeLists.txt`: pre-create `WrapOpenGL::WrapOpenGL` as an INTERFACE IMPORTED target **before** `find_package(Qt6)`. Qt's `FindWrapOpenGL.cmake` then takes its "target already exists → early return" path (lines 6-9 of the module) and skips the AGL fallback entirely. This fixes all `Qt6::Gui` consumers in the build tree, not just qgeoview — the previous qgeoview-specific scrub only cleaned qgeoview's own LINK_LIBRARIES and couldn't reach Qt6::Gui's interface.

Full root cause analysis is in the [#140 comment](https://github.com/Fincept-Corporation/FinceptTerminal/issues/140#issuecomment-4277521087).

## How to Test
1. On macOS 14+ (Sonoma or later) with Xcode 15+/Qt 6.8.3
2. `cmake --preset macos-release && cmake --build build/macos-release`
3. Verify `build/macos-release/FinceptTerminal.app/Contents/MacOS/FinceptTerminal` exists (~27 MB)
4. Without this patch, the build fails at step 4/341: `ld: framework 'AGL' not found`

## Checklist
- [x] Builds without errors on target platform (macOS 26, Qt 6.8.3)
- [x] UI thread is never blocked — N/A (build-only change)
- [x] Timers start/stop in `showEvent()`/`hideEvent()` — N/A
- [x] No raw `QProcess` for Python — N/A
- [x] No sensitive data (API keys, credentials) committed
- [x] Tested manually on: macOS (Apple Silicon, Xcode 26, Qt 6.8.3)

## Screenshots
N/A (build system change, no UI impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)