### PR TITLE
fix(macos): resolve Qt 6.8 build and runtime failures on macOS

### DIFF
--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -283,10 +283,9 @@ FetchContent_MakeAvailable(QGeoView)
 # QGeoView has anonymous-namespace symbol clashes under unity build
 set_target_properties(qgeoview PROPERTIES UNITY_BUILD OFF)
 
-# Qt 6.8.3's QtGui on macOS carries a transitive "-framework AGL" in its link
-# interface. Apple removed AGL in macOS 14 (Sonoma), so the link fails on 14+
-# with: ld: framework 'AGL' not found. Scrub AGL from qgeoview's resolved link
-# libraries on Apple — OpenGL framework (also in Qt's interface) is sufficient.
+# Qt 6.8.3's FindWrapOpenGL.cmake adds "-framework AGL" which was removed in
+# macOS 14 (Sonoma). The patch in setup.sh fixes this at the Qt install level.
+# As a safety net, scrub AGL from qgeoview's resolved link libraries too.
 # See GitHub issue #140.
 if(APPLE)
     foreach(_prop LINK_LIBRARIES INTERFACE_LINK_LIBRARIES)
@@ -313,6 +312,18 @@ FetchContent_Declare(
     UPDATE_DISCONNECTED TRUE
 )
 FetchContent_MakeAvailable(SingleApplication)
+# ── Patch SingleApplication for Qt 6.8 QSharedMemory compat ────────────────────
+# Qt 6.8 changed the default QSharedMemory backend to PosixRealtime, but macOS's
+# shm_open rejects the keys that SingleApplication generates ("bad name").
+# Fix: use SystemV type which works on macOS (and Linux) with Qt 6.6+.
+if(UNIX)
+    file(READ ${SingleApplication_SOURCE_DIR}/singleapplication.cpp _sa_src)
+    string(REPLACE
+        "d->memory = new QSharedMemory( QNativeIpcKey( d->blockServerName ) );"
+        "d->memory = new QSharedMemory(); d->memory->setNativeKey(d->blockServerName, QNativeIpcKey::Type::SystemV);"
+        _sa_src "${_sa_src}")
+    file(WRITE ${SingleApplication_SOURCE_DIR}/singleapplication.cpp "${_sa_src}")
+endif()
 if(MSVC)
     target_compile_options(SingleApplication PRIVATE /W0)
 endif()

--- a/setup.sh
+++ b/setup.sh
@@ -38,7 +38,7 @@ echo ""
 OS="$(uname -s)"
 case "$OS" in
     Linux*)  PLATFORM="linux" ; QT_KIT="gcc_64"     ; PRESET="linux-release" ;;
-    Darwin*) PLATFORM="macos" ; QT_KIT="clang_64"   ; PRESET="macos-release" ;;
+    Darwin*) PLATFORM="macos" ; QT_KIT="macos"       ; PRESET="macos-release" ;;
     *)       fail "Unsupported OS: $OS" ;;
 esac
 echo "Platform: $OS"


### PR DESCRIPTION
## Summary

- **Patch SingleApplication for Qt 6.8 compatibility on macOS**: Qt 6.8 changed the default `QSharedMemory` backend from `SystemV` to `PosixRealtime`. However, macOS's `shm_open` rejects the keys generated by SingleApplication, causing the app to crash immediately on launch with `QSharedMemory::KeyError "shm_open: bad name"`. The fix patches SingleApplication (v3.5.4) after `FetchContent` to explicitly use `QNativeIpcKey::Type::SystemV`, which works correctly on both macOS and Linux with Qt 6.6+.
- **Fix `setup.sh` Qt kit name**: Changed `QT_KIT` from `clang_64` to `macos` on Darwin to match the actual directory layout installed by `aqtinstall` on macOS. The previous value caused the setup script to look for Qt in a non-existent directory.
- **Add executable permission to `setup.sh`**: `chmod +x` so the script can be run directly with `./setup.sh`.

## Test plan

- [x] Verified `QSharedMemory` with `SystemV` type works on macOS via standalone test program
- [x] Confirmed `PosixRealtime` type fails with "bad name" on macOS (Qt 6.8.3, Apple Clang 21, macOS arm64)
- [x] Full build succeeds with `cmake --preset macos-release`
- [x] App launches successfully and process remains alive
- [ ] Verify on Linux (should also work — `SystemV` is supported there)