### PR TITLE
Fix macOS 14 compatibility by pinning deployment target

### DIFF
--- a/.github/workflows/build-cpp.yml
+++ b/.github/workflows/build-cpp.yml
@@ -50,7 +50,7 @@ jobs:
             artifact: FinceptTerminal-macOS-arm64
             exe: FinceptTerminal
             qt_arch: clang_64
-            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=arm64"
+            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0"
 
           # ---- macOS x64 (Intel) ----
           # Cross-compiled on ARM64 runner. CMakeLists.txt auto-disables GGML_NATIVE
@@ -61,7 +61,7 @@ jobs:
             artifact: FinceptTerminal-macOS-x64
             exe: FinceptTerminal
             qt_arch: clang_64
-            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=x86_64"
+            cmake_extra: "-DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0"
 
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.platform }} ${{ matrix.arch }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -537,6 +537,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
             -DCMAKE_PREFIX_PATH="${QT_ROOT_DIR}" \
             -DCMAKE_OSX_ARCHITECTURES=arm64 \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 

--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -44,10 +44,18 @@ endif()
 # Without this, CMake embeds build-tree rpaths (e.g. _deps/qgeoview-build/lib)
 # and CPack IFW fails trying to delete them after macdeployqt already rewrote them.
 if(APPLE)
+    # If not explicitly provided by the caller/preset, pin the minimum
+    # supported macOS version so builds on newer runners do not accidentally
+    # produce bundles that require that newer host OS at runtime.
+    if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING
+            "Minimum macOS version supported by Fincept Terminal" FORCE)
+    endif()
     set(CMAKE_MACOSX_RPATH ON)
     set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks;@executable_path/../lib")
     set(CMAKE_BUILD_WITH_INSTALL_RPATH OFF)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+    message(STATUS "macOS deployment target: ${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
 
 # Export compile_commands.json for clang-tidy

--- a/fincept-qt/CMakePresets.json
+++ b/fincept-qt/CMakePresets.json
@@ -58,7 +58,7 @@
       "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Darwin" },
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "11.0",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "13.0",
         "CMAKE_PREFIX_PATH": "$env{HOME}/Qt/6.8.3/macos"
       }
     },


### PR DESCRIPTION
Problem: App built on macOS 15 could require newer runtime and show “not compatible” on macOS 14.8.
Changes:
CMakeLists.txt — pin CMAKE_OSX_DEPLOYMENT_TARGET to 13.0
CMakePresets.json — set CMAKE_OSX_DEPLOYMENT_TARGET to 13.0
build-cpp.yml — pass -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 for macOS builds
release.yml — pass -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 for DMG build
Testing: Rebuild macOS artifacts and verify file / lipo -info show compatible slice and LSMinimumSystemVersion ≤ 14.8.
Note: After merge, CI/release must rebuild and publish new DMG.