### PR TITLE
fix(mcp, scripts): fix MCP server arg splitting and AKShare analysis crash

### DIFF
--- a/fincept-qt/scripts/akshare_analysis.py
+++ b/fincept-qt/scripts/akshare_analysis.py
@@ -11,7 +11,7 @@ import json
 import pandas as pd
 import akshare as ak
 from typing import Dict, Any, List, Optional, Union
-from datetime import datetime, timedelta
+from datetime import datetime, date, timedelta
 import traceback
 import time
 
@@ -967,7 +967,7 @@ def main():
     # Custom JSON encoder for date objects
     class DateTimeEncoder(json.JSONEncoder):
         def default(self, obj):
-            if isinstance(obj, (datetime, datetime.date)):
+            if isinstance(obj, (datetime, date)):
                 return obj.isoformat()
             return super().default(obj)
 

--- a/fincept-qt/scripts/akshare_analysis.py
+++ b/fincept-qt/scripts/akshare_analysis.py
@@ -158,6 +158,14 @@ class StockAnalysisWrapper:
             "timestamp": int(datetime.now().timestamp())
         }
 
+    def _convert_dataframe_to_json_safe(self, df: pd.DataFrame) -> List[Dict[str, Any]]:
+        """Convert DataFrame to JSON-safe format by converting datetime columns to strings"""
+        df_copy = df.copy()
+        for col in df_copy.columns:
+            if pd.api.types.is_datetime64_any_dtype(df_copy[col]):
+                df_copy[col] = df_copy[col].astype(str)
+        return df_copy.to_dict('records')
+
     def _validate_and_format_dataframe(self, df: pd.DataFrame, min_rows: int = 1) -> Dict[str, Any]:
         """Validate and format DataFrame for consistent output"""
         if df is None or df.empty:
@@ -183,7 +191,7 @@ class StockAnalysisWrapper:
 
         return {
             "success": True,
-            "data": df_clean.to_dict('records'),
+            "data": self._convert_dataframe_to_json_safe(df_clean),
             "count": len(df_clean),
             "timestamp": int(datetime.now().timestamp()),
             "data_quality": "high",
@@ -915,9 +923,9 @@ def main():
     endpoint = sys.argv[1]
     args = sys.argv[2:] if len(sys.argv) > 2 else []
 
-    # Map endpoint names to method calls
+    # Map endpoint names to method calls (aliases)
     endpoint_map = {
-                "get_all_endpoints": wrapper.get_all_stock_analysis_endpoints,
+        "get_all_endpoints": wrapper.get_all_stock_analysis_endpoints,
         "get_analysis_summary": wrapper.get_analysis_summary,
 
         # Technical Indicators
@@ -956,70 +964,43 @@ def main():
         "baidu_polls": wrapper.get_baidu_poll_data
     }
 
+    # Custom JSON encoder for date objects
+    class DateTimeEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, (datetime, datetime.date)):
+                return obj.isoformat()
+            return super().default(obj)
+
+    # Resolution logic: map -> explicit get_ -> direct hasattr
     method = endpoint_map.get(endpoint)
+    if not method:
+        method_name = f"get_{endpoint}" if not endpoint.startswith("get_") else endpoint
+        if hasattr(wrapper, method_name):
+            method = getattr(wrapper, method_name)
+
     if method:
-        if args:
-            # For endpoints that require parameters
-            try:
-                if endpoint in ["individual_fund_flow", "cost_layer", "order_book"]:
-                    result = method(symbol=args[0] if args else "sh600000")
-                elif endpoint in ["valuation_analysis"]:
-                    result = method(market=args[0] if args else "sh")
-                elif endpoint == "stock_comments":
-                    result = method(symbol=args[0] if args else None)
-                else:
-                    result = method(*args)
-            except Exception as e:
-                result = {"error": str(e), "endpoint": endpoint}
-        else:
-            result = method()
-        print(json.dumps(result, indent=2, ensure_ascii=True))
+        try:
+            # Smart argument handling
+            if endpoint in ["individual_fund_flow", "cost_layer", "order_book"] or \
+               method.__name__ in ["get_individual_stock_fund_flow", "get_cost_layer_analysis", "get_order_book_analysis"]:
+                result = method(symbol=args[0] if args else "sh600000")
+            elif endpoint in ["valuation_analysis"] or method.__name__ == "get_valuation_analysis":
+                result = method(market=args[0] if args else "sh")
+            elif endpoint == "stock_comments" or method.__name__ == "get_stock_comments":
+                result = method(symbol=args[0] if args else None)
+            else:
+                result = method(*args) if args else method()
+        except Exception as e:
+            result = {"success": False, "error": str(e), "endpoint": endpoint, "traceback": traceback.format_exc()}
     else:
-        print(json.dumps({
+        result = {
+            "success": False,
             "error": f"Unknown endpoint: {endpoint}",
             "available_endpoints": list(endpoint_map.keys())
-        }, indent=2))
+        }
 
+    print(json.dumps(result, ensure_ascii=True, cls=DateTimeEncoder))
 
-
-# ==================== CLI ====================
-
-# ==================== CLI ====================
 if __name__ == "__main__":
-    import sys
-    import json
-
-    # Get wrapper instance
-    wrapper = StockAnalysisWrapper()
-
-    if len(sys.argv) < 2:
-        print(json.dumps({"error": "Usage: python akshare_analysis.py <endpoint> [args...]"}))
-        sys.exit(1)
-
-    endpoint = sys.argv[1]
-    args = sys.argv[2:] if len(sys.argv) > 2 else []
-
-    # Handle get_all_endpoints
-    if endpoint == "get_all_endpoints":
-        if hasattr(wrapper, 'get_all_available_endpoints'):
-            result = wrapper.get_all_available_endpoints()
-        elif hasattr(wrapper, 'get_all_endpoints'):
-            result = wrapper.get_all_endpoints()
-        else:
-            result = {"success": False, "error": "Endpoint list not available"}
-        print(json.dumps(result, ensure_ascii=True))
-        sys.exit(0)
-
-    # Dynamic method resolution
-    method_name = f"get_{endpoint}" if not endpoint.startswith("get_") else endpoint
-
-    if hasattr(wrapper, method_name):
-        method = getattr(wrapper, method_name)
-        try:
-            result = method(*args) if args else method()
-            print(json.dumps(result, ensure_ascii=True))
-        except Exception as e:
-            print(json.dumps({"success": False, "error": str(e), "endpoint": endpoint}))
-    else:
-        print(json.dumps({"success": False, "error": f"Unknown endpoint: {endpoint}. Method '{method_name}' not found."}))
+    main()
 

--- a/fincept-qt/src/mcp/McpManager.cpp
+++ b/fincept-qt/src/mcp/McpManager.cpp
@@ -117,15 +117,15 @@ Result<void> McpManager::save_server(const McpServerConfig& config) {
     srv.status = "stopped";
 
     // Store args and env as JSON strings to correctly handle spaces and special chars
-    QJsonArray argsArr;
+    QJsonArray args_arr;
     for (const auto& arg : config.args)
-        argsArr.append(arg);
-    srv.args = QJsonDocument(argsArr).toJson(QJsonDocument::Compact);
+        args_arr.append(arg);
+    srv.args = QJsonDocument(args_arr).toJson(QJsonDocument::Compact);
 
-    QJsonObject envObj;
+    QJsonObject env_obj;
     for (auto it = config.env.constBegin(); it != config.env.constEnd(); ++it)
-        envObj[it.key()] = it.value();
-    srv.env = QJsonDocument(envObj).toJson(QJsonDocument::Compact);
+        env_obj[it.key()] = it.value();
+    srv.env = QJsonDocument(env_obj).toJson(QJsonDocument::Compact);
 
     auto r = McpServerRepository::instance().save(srv);
     if (r.is_err())

--- a/fincept-qt/src/mcp/McpManager.cpp
+++ b/fincept-qt/src/mcp/McpManager.cpp
@@ -5,6 +5,9 @@
 #include "core/logging/Logger.h"
 #include "storage/repositories/McpServerRepository.h"
 
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 #include <QUuid>
 
 namespace fincept::mcp {
@@ -42,14 +45,43 @@ void McpManager::initialize() {
         cfg.name = srv.name;
         cfg.description = srv.description;
         cfg.command = srv.command;
-        cfg.args = srv.args.split(' ', Qt::SkipEmptyParts);
         cfg.category = srv.category;
         cfg.enabled = srv.enabled;
         cfg.auto_start = srv.auto_start;
         cfg.status = ServerStatus::Stopped;
 
-        // Parse env JSON (stored as "KEY=VALUE KEY2=VALUE2")
-        if (!srv.env.isEmpty()) {
+        // Parse args: Try JSON array first (supports spaces), fallback to legacy space-split
+        bool args_parsed = false;
+        if (srv.args.trimmed().startsWith('[')) {
+            QJsonDocument doc = QJsonDocument::fromJson(srv.args.toUtf8());
+            if (doc.isArray()) {
+                QJsonArray arr = doc.array();
+                for (const auto& val : arr) {
+                    if (val.isString())
+                        cfg.args.append(val.toString());
+                }
+                args_parsed = true;
+            }
+        }
+
+        if (!args_parsed) {
+            cfg.args = srv.args.split(' ', Qt::SkipEmptyParts);
+        }
+
+        // Parse env: Try JSON object first, fallback to legacy "KEY=VAL KEY2=VAL2" format
+        bool env_parsed = false;
+        if (srv.env.trimmed().startsWith('{')) {
+            QJsonDocument doc = QJsonDocument::fromJson(srv.env.toUtf8());
+            if (doc.isObject()) {
+                QJsonObject obj = doc.object();
+                for (auto it = obj.begin(); it != obj.end(); ++it) {
+                    cfg.env[it.key()] = it.value().toString();
+                }
+                env_parsed = true;
+            }
+        }
+
+        if (!env_parsed && !srv.env.isEmpty()) {
             for (const auto& pair : srv.env.split(' ', Qt::SkipEmptyParts)) {
                 int eq = pair.indexOf('=');
                 if (eq > 0)
@@ -79,16 +111,21 @@ Result<void> McpManager::save_server(const McpServerConfig& config) {
     srv.name = config.name;
     srv.description = config.description;
     srv.command = config.command;
-    srv.args = config.args.join(' ');
     srv.category = config.category;
     srv.enabled = config.enabled;
     srv.auto_start = config.auto_start;
     srv.status = "stopped";
 
-    QStringList env_pairs;
+    // Store args and env as JSON strings to correctly handle spaces and special chars
+    QJsonArray argsArr;
+    for (const auto& arg : config.args)
+        argsArr.append(arg);
+    srv.args = QJsonDocument(argsArr).toJson(QJsonDocument::Compact);
+
+    QJsonObject envObj;
     for (auto it = config.env.constBegin(); it != config.env.constEnd(); ++it)
-        env_pairs.append(it.key() + "=" + it.value());
-    srv.env = env_pairs.join(' ');
+        envObj[it.key()] = it.value();
+    srv.env = QJsonDocument(envObj).toJson(QJsonDocument::Compact);
 
     auto r = McpServerRepository::instance().save(srv);
     if (r.is_err())


### PR DESCRIPTION
#### Summary of Improvements

   1. Fixed Critical Crash in akshare_analysis.py:
       * Issue: I identified a major AttributeError where the script called a missing method _convert_dataframe_to_json_safe upon successfully fetching data. This caused the script to crash immediately after a successful API call.
       * Fix: Added the missing _convert_dataframe_to_json_safe method to the StockAnalysisWrapper class and updated the validation logic to use it.
       * Cleanup: Consolidated redundant CLI entry points into a single, robust main() function with improved JSON serialization for dates and better error handling.
       
   2. Improved MCP Server Configuration in McpManager.cpp:
       * Issue: Arguments and environment variables for external MCP servers were stored and parsed as space-separated strings. This caused failures for any value containing a space (e.g., C:\Program Files\... on Windows).
       * Fix: Re-implemented the configuration storage using JSON serialization via QJsonDocument. This ensures that spaces and special characters are preserved correctly.
       * Compatibility: Maintained full backward compatibility by falling back to the legacy space-split logic if a configuration string is not valid JSON.


   * Files Modified:
       * fincept-qt/scripts/akshare_analysis.py
       * fincept-qt/src/mcp/McpManager.cpp
