### PR TITLE
fix(docker): update Qt version to 6.8.3 and add missing module

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,13 @@ fincept-qt/build/
 fincept-qt/uitest/
 tmpqt/
 .git/
+images/
+docs/
+.github/
+*.md
+package.json
+package-lock.json
+funding.json
+updates.json
+fincept_icon.ico
+setup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM debian:12-slim AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG QT_VERSION=6.7.2
+ARG QT_VERSION=6.8.3
 ARG QT_ARCH=gcc_64
 
 # Build toolchain + Qt runtime system deps (for Qt to link against)
@@ -32,7 +32,7 @@ ENV QT_ROOT=/opt/Qt
 RUN pip3 install --break-system-packages --no-cache-dir aqtinstall \
     && python3 -m aqt install-qt linux desktop ${QT_VERSION} ${QT_ARCH} \
         --outputdir ${QT_ROOT} \
-        --modules qtcharts qtwebsockets qtmultimedia qtspeech
+        --modules qtcharts qtwebsockets qtmultimedia qtmultimediawidgets qtspeech
 
 ENV CMAKE_PREFIX_PATH="${QT_ROOT}/${QT_VERSION}/${QT_ARCH}"
 ENV PATH="${CMAKE_PREFIX_PATH}/bin:${PATH}"
@@ -53,7 +53,7 @@ RUN rm -rf build \
 FROM debian:12-slim AS runtime
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG QT_VERSION=6.7.2
+ARG QT_VERSION=6.8.3
 ARG QT_ARCH=gcc_64
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -93,22 +93,19 @@ The script handles: compiler check, CMake, Qt6, Python, build, and launch.
 
 ---
 
-### Option 3 — Docker
+### Option 3 — Docker (CI / Developer Environments)
+
+> **Note:** Docker is intended for CI/CD testing and development environments only.
+> For the best experience, use the pre-built installers in **Option 1** above.
+> Docker requires Linux with X11. Windows and macOS are not supported.
 
 ```bash
-# Pull and run
-docker pull ghcr.io/fincept-corporation/fincept-terminal:latest
-docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
-    ghcr.io/fincept-corporation/fincept-terminal:latest
-
-# Or build from source
+# Build from source (Linux + X11 required)
 git clone https://github.com/Fincept-Corporation/FinceptTerminal.git
 cd FinceptTerminal
 docker build -t fincept-terminal .
 docker run --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix fincept-terminal
 ```
-
-> **Note:** Docker is primarily intended for Linux. macOS and Windows require additional XServer configuration.
 
 ---
 


### PR DESCRIPTION
Dockerfile used Qt 6.7.2 but CMakeLists.txt requires 6.8.3 EXACT, causing docker build to fail at CMake configure. Also adds the missing qtmultimediawidgets module. README Docker section clarified as CI/dev only.