### PR TITLE
fix(security): scope Fincept auth headers to configured API host

### DIFF
--- a/fincept-qt/src/network/http/HttpClient.cpp
+++ b/fincept-qt/src/network/http/HttpClient.cpp
@@ -16,16 +16,30 @@ HttpClient::HttpClient() {
 }
 
 QNetworkRequest HttpClient::build_request(const QString& url) const {
-    QString full_url = url.startsWith("http") ? url : (base_url_ + url);
+    const bool is_relative = !url.startsWith("http");
+    const QString full_url = is_relative ? (base_url_ + url) : url;
     QUrl qurl(full_url);
     QNetworkRequest req{qurl};
     req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     req.setHeader(QNetworkRequest::UserAgentHeader, "FinceptTerminal/4.0");
-    if (!api_key_.isEmpty()) {
-        req.setRawHeader("X-API-Key", api_key_.toUtf8());
-    }
-    if (!session_token_.isEmpty()) {
-        req.setRawHeader("X-Session-Token", session_token_.toUtf8());
+
+    // Only attach Fincept auth headers when the request targets the configured
+    // Fincept API host. Notification providers (Slack, Discord, Telegram,
+    // PagerDuty, user webhooks, …) and other services pass absolute third-party
+    // URLs through this same singleton — without this guard their servers would
+    // receive the user's X-API-Key and X-Session-Token in every call.
+    const bool same_host = is_relative || [&]() {
+        const QUrl base(base_url_);
+        return !base.host().isEmpty() && qurl.host().compare(base.host(), Qt::CaseInsensitive) == 0;
+    }();
+
+    if (same_host) {
+        if (!api_key_.isEmpty()) {
+            req.setRawHeader("X-API-Key", api_key_.toUtf8());
+        }
+        if (!session_token_.isEmpty()) {
+            req.setRawHeader("X-Session-Token", session_token_.toUtf8());
+        }
     }
     return req;
 }


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** Credential leak to third-party services (header scoping bug)
**Severity:** High
**Location:** `fincept-qt/src/network/http/HttpClient.cpp` — `HttpClient::build_request`

### Description

`HttpClient` is a singleton that's shared by the Fincept API client *and* every notification provider / outbound integration in the app. `build_request()` unconditionally attaches the user's active Fincept `X-API-Key` and `X-Session-Token` to every request — regardless of whether the URL points at the configured `base_url_` (the Fincept API) or at a completely unrelated third-party host.

Affected call sites I traced while auditing v4.0.2:

- `services/notifications/providers/SlackProvider.cpp` → `hooks.slack.com`
- `services/notifications/providers/DiscordProvider.cpp` → `discord.com/api/webhooks/...`
- `services/notifications/providers/TelegramProvider.cpp` → `api.telegram.org`
- `services/notifications/providers/PagerDutyProvider.cpp` → `events.pagerduty.com`
- `services/notifications/providers/PushoverProvider.cpp` → `api.pushover.net`
- `services/notifications/providers/WebhookProvider.cpp` → arbitrary user-configured URL
- `services/notifications/providers/GotifyProvider.cpp`, `NtfyProvider.cpp`, `MattermostProvider.cpp`, `TeamsProvider.cpp`, `WhatsAppProvider.cpp`, `SMSProvider.cpp`, `EmailProvider.cpp`, `PushbulletProvider.cpp`, `OpsgenieProvider.cpp`

All of these send Fincept credentials in request headers to the notification service on every alert.

### Impact

Every notification the user triggers ships their Fincept `X-API-Key` and `X-Session-Token` — the ones that actually authenticate real Fincept API calls — to whichever third-party endpoint they've wired up. Those servers log headers in the normal course of operation, so the credentials end up in:

- Discord / Slack / Telegram infrastructure logs (shared workspaces, incident response tooling, etc.).
- PagerDuty, Pushover, Gotify, etc. request logs.
- Any user-configured webhook — including arbitrary URLs an attacker could induce a user to paste in via phishing/social engineering, specifically to harvest the tokens.

Anyone able to read those logs, or anyone controlling a shared/compromised notification endpoint, gets valid Fincept credentials for the affected user with no further interaction.

### Fix

In `build_request()`, attach `X-API-Key` / `X-Session-Token` only when:

1. The URL is relative (implicitly prefixed with `base_url_`), **or**
2. The absolute URL's host matches the configured `base_url_`'s host (case-insensitive).

Requests to any other host leave without Fincept credentials. All existing Fincept API call sites pass relative paths (e.g. `/news/analyze`), so they continue to authenticate exactly as before — only the cross-origin leak path is closed.

Minimal diff, single file, no behavioral change for first-party API traffic.

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner