### PR TITLE
fix: clarify SuperAgent missing-model error for API users

### DIFF
--- a/fincept-qt/scripts/agents/finagent_core/super_agent.py
+++ b/fincept-qt/scripts/agents/finagent_core/super_agent.py
@@ -538,7 +538,12 @@ class SuperAgent:
         if not model_provider or not model_id:
             return {
                 "success": False,
-                "error": "No LLM model configured. Please configure a model provider and model ID in Settings > LLM Configuration.",
+                "error": (
+                    "No LLM model configured. Configure a model provider and "
+                    "model ID in Settings > LLM Configuration, or pass "
+                    'user_config={"model": {"provider": "...", "model_id": "..."}} '
+                    "when calling the API programmatically."
+                ),
                 "routing": {
                     "intent": routing.intent.value,
                     "agent_id": routing.agent_id,

--- a/fincept-qt/scripts/agents/finagent_core/tests/test_super_agent.py
+++ b/fincept-qt/scripts/agents/finagent_core/tests/test_super_agent.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+
+from finagent_core.super_agent import SuperAgent
+
+
+def test_execute_missing_model_error_mentions_programmatic_path(monkeypatch):
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "finagent_core.core_agent",
+        SimpleNamespace(CoreAgent=object),
+    )
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "finagent_core.agent_loader",
+        SimpleNamespace(get_loader=lambda: None),
+    )
+
+    agent = SuperAgent(api_keys={})
+
+    result = agent.execute("Analyze AAPL")
+
+    assert result["success"] is False
+    assert "Settings > LLM Configuration" in result["error"]
+    assert 'user_config={"model": {' in result["error"]


### PR DESCRIPTION
## Summary
- clarify the missing-model error in `SuperAgent.execute()` so it no longer assumes GUI-only usage
- mention the programmatic `user_config={"model": {...}}` path directly in the returned error
- add a focused regression test for the missing-model response

Closes #201
