### PR TITLE
fix: improve error message for missing LLM config (#150)

### DIFF
--- a/fincept-qt/scripts/agents/finagent_core/super_agent.py
+++ b/fincept-qt/scripts/agents/finagent_core/super_agent.py
@@ -538,7 +538,12 @@ class SuperAgent:
         if not model_provider or not model_id:
             return {
                 "success": False,
-                "error": "No LLM model configured. Please configure a model provider and model ID in Settings > LLM Configuration.",
+                "error": (
+                    "No LLM model configured. "
+                    "GUI users: go to Settings > LLM Configuration. "
+                    "Programmatic users: pass user_config={'model': {'provider': '...', 'model_id': '...'}} "
+                    "to execute() or execute_multi()."
+                    ),
                 "routing": {
                     "intent": routing.intent.value,
                     "agent_id": routing.agent_id,


### PR DESCRIPTION
## Summary
Fixes Bug 3 from issue #150.

## Problem
The previous error message only mentioned the GUI settings path:
> "No LLM model configured. Please configure a model provider and model ID in Settings > LLM Configuration."

This gives programmatic users no actionable hint.

## Fix
Updated message now covers both usage paths:
- GUI: Settings > LLM Configuration
- Programmatic: user_config={'model': {'provider': '...', 'model_id': '...'}}

## Related
- Issue: #150
- Bugs 1 & 2 fixed in: #200