### PR TITLE
Add unit test suite for analytics modules (DCF, VaR, Sharpe)

### DIFF
--- a/fincept-qt/scripts/Analytics/analytics_core.py
+++ b/fincept-qt/scripts/Analytics/analytics_core.py
@@ -1,0 +1,339 @@
+"""
+fincept-cpp/scripts/Analytics/analytics_core.py
+
+Core financial analytics module for Fincept Terminal.
+Implements DCF valuation, Value-at-Risk, and Sharpe/risk metrics.
+All functions accept/return plain Python types so they can be
+serialised to JSON and consumed by python_runner.cpp.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import sys
+from typing import Any
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DCF (Discounted Cash Flow) Valuation
+# ──────────────────────────────────────────────────────────────────────────────
+
+def dcf_valuation(
+    free_cash_flows: list[float],
+    discount_rate: float,
+    terminal_growth_rate: float,
+    shares_outstanding: float,
+) -> dict[str, Any]:
+    """
+    Compute intrinsic value per share via a multi-stage DCF model.
+
+    Parameters
+    ----------
+    free_cash_flows      : Explicit forecast FCFs (year 1 … N), in any currency unit.
+    discount_rate        : WACC / required return (e.g. 0.10 for 10 %).
+    terminal_growth_rate : Perpetual growth rate after the forecast horizon (e.g. 0.03).
+    shares_outstanding   : Diluted share count (same unit as FCFs / share count).
+
+    Returns
+    -------
+    dict with keys:
+        pv_explicit_fcfs   – PV of the forecast-period cash flows
+        terminal_value     – Gordon-growth terminal value (undiscounted)
+        pv_terminal_value  – PV of terminal value
+        total_intrinsic_value – enterprise value proxy
+        intrinsic_value_per_share
+    """
+    if discount_rate <= terminal_growth_rate:
+        raise ValueError(
+            "discount_rate must be strictly greater than terminal_growth_rate "
+            f"(got {discount_rate} vs {terminal_growth_rate})"
+        )
+    if shares_outstanding <= 0:
+        raise ValueError("shares_outstanding must be positive")
+    if not free_cash_flows:
+        raise ValueError("free_cash_flows must not be empty")
+
+    n = len(free_cash_flows)
+
+    pv_explicit = sum(
+        fcf / (1 + discount_rate) ** (i + 1)
+        for i, fcf in enumerate(free_cash_flows)
+    )
+
+    last_fcf = free_cash_flows[-1]
+    terminal_value = last_fcf * (1 + terminal_growth_rate) / (
+        discount_rate - terminal_growth_rate
+    )
+    pv_terminal = terminal_value / (1 + discount_rate) ** n
+
+    total_value = pv_explicit + pv_terminal
+    value_per_share = total_value / shares_outstanding
+
+    return {
+        "pv_explicit_fcfs": round(pv_explicit, 4),
+        "terminal_value": round(terminal_value, 4),
+        "pv_terminal_value": round(pv_terminal, 4),
+        "total_intrinsic_value": round(total_value, 4),
+        "intrinsic_value_per_share": round(value_per_share, 4),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Value-at-Risk (VaR) — Historical Simulation & Parametric
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _mean(data: list[float]) -> float:
+    return sum(data) / len(data)
+
+
+def _std(data: list[float], ddof: int = 1) -> float:
+    m = _mean(data)
+    variance = sum((x - m) ** 2 for x in data) / (len(data) - ddof)
+    return math.sqrt(variance)
+
+
+def historical_var(
+    returns: list[float],
+    confidence_level: float = 0.95,
+    portfolio_value: float = 1_000_000.0,
+) -> dict[str, Any]:
+    """
+    Historical-simulation VaR.
+
+    Parameters
+    ----------
+    returns          : Daily (or periodic) return series as decimals (e.g. 0.01 = 1 %).
+    confidence_level : E.g. 0.95 for 95 % VaR.
+    portfolio_value  : Portfolio NAV in currency units.
+
+    Returns
+    -------
+    dict with var_percentage, var_currency, cvar_percentage, cvar_currency.
+    """
+    if not returns:
+        raise ValueError("returns must not be empty")
+    if not 0 < confidence_level < 1:
+        raise ValueError("confidence_level must be between 0 and 1 (exclusive)")
+
+    sorted_returns = sorted(returns)
+    index = int((1 - confidence_level) * len(sorted_returns))
+    index = max(0, min(index, len(sorted_returns) - 1))
+
+    var_pct = -sorted_returns[index]
+
+    # CVaR (Expected Shortfall) — mean of losses beyond VaR
+    tail = sorted_returns[: index + 1]
+    cvar_pct = -_mean(tail) if tail else var_pct
+
+    return {
+        "var_percentage": round(var_pct, 6),
+        "var_currency": round(var_pct * portfolio_value, 2),
+        "cvar_percentage": round(cvar_pct, 6),
+        "cvar_currency": round(cvar_pct * portfolio_value, 2),
+        "confidence_level": confidence_level,
+        "observations": len(returns),
+    }
+
+
+def parametric_var(
+    returns: list[float],
+    confidence_level: float = 0.95,
+    portfolio_value: float = 1_000_000.0,
+    z_score: float | None = None,
+) -> dict[str, Any]:
+    """
+    Parametric (variance-covariance) VaR assuming normal distribution.
+
+    z_score defaults to the standard Normal quantile for the given
+    confidence_level if not supplied explicitly.
+    """
+    if not returns:
+        raise ValueError("returns must not be empty")
+    if not 0 < confidence_level < 1:
+        raise ValueError("confidence_level must be between 0 and 1 (exclusive)")
+
+    # Approximate Normal quantile via rational approximation (Beasley-Springer-Moro)
+    if z_score is None:
+        z_score = _norm_ppf(confidence_level)
+
+    mu = _mean(returns)
+    sigma = _std(returns, ddof=1)
+
+    var_pct = -(mu - z_score * sigma)
+
+    return {
+        "var_percentage": round(var_pct, 6),
+        "var_currency": round(var_pct * portfolio_value, 2),
+        "mean_return": round(mu, 6),
+        "volatility": round(sigma, 6),
+        "z_score": round(z_score, 4),
+        "confidence_level": confidence_level,
+    }
+
+
+def _norm_ppf(p: float) -> float:
+    """Rational approximation of the inverse standard Normal CDF."""
+    # Abramowitz & Stegun 26.2.17 — accurate to ~4.5e-4
+    a = [2.515517, 0.802853, 0.010328]
+    b = [1.432788, 0.189269, 0.001308]
+    t = math.sqrt(-2.0 * math.log(1.0 - p))
+    num = a[0] + a[1] * t + a[2] * t**2
+    den = 1.0 + b[0] * t + b[1] * t**2 + b[2] * t**3
+    return t - num / den
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sharpe, Sortino, Calmar, Max-Drawdown
+# ──────────────────────────────────────────────────────────────────────────────
+
+def sharpe_ratio(
+    returns: list[float],
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = 252,
+) -> dict[str, Any]:
+    """
+    Annualised Sharpe ratio.
+
+    Parameters
+    ----------
+    returns          : Periodic (e.g. daily) return series.
+    risk_free_rate   : Annual risk-free rate as a decimal.
+    periods_per_year : 252 for daily, 52 for weekly, 12 for monthly.
+    """
+    if len(returns) < 2:
+        raise ValueError("Need at least 2 return observations")
+
+    periodic_rf = risk_free_rate / periods_per_year
+    excess = [r - periodic_rf for r in returns]
+    mu_excess = _mean(excess)
+    sigma_excess = _std(excess, ddof=1)
+
+    if sigma_excess == 0:
+        raise ValueError("Return series has zero variance — Sharpe undefined")
+
+    sharpe = (mu_excess / sigma_excess) * math.sqrt(periods_per_year)
+    return {"sharpe_ratio": round(sharpe, 4), "annualised": True}
+
+
+def sortino_ratio(
+    returns: list[float],
+    risk_free_rate: float = 0.0,
+    periods_per_year: int = 252,
+    target_return: float = 0.0,
+) -> dict[str, Any]:
+    """Annualised Sortino ratio (penalises only downside deviation)."""
+    if len(returns) < 2:
+        raise ValueError("Need at least 2 return observations")
+
+    periodic_rf = risk_free_rate / periods_per_year
+    mu = _mean(returns)
+
+    downside = [min(r - target_return, 0) for r in returns]
+    downside_std = math.sqrt(sum(d**2 for d in downside) / len(downside))
+
+    if downside_std == 0:
+        raise ValueError("No downside deviations — Sortino undefined")
+
+    sortino = ((mu - periodic_rf) / downside_std) * math.sqrt(periods_per_year)
+    return {"sortino_ratio": round(sortino, 4), "annualised": True}
+
+
+def max_drawdown(prices: list[float]) -> dict[str, Any]:
+    """
+    Maximum drawdown from a price (or NAV) series.
+
+    Returns the worst peak-to-trough decline as a positive percentage.
+    """
+    if not prices:
+        raise ValueError("prices must not be empty")
+    if any(p <= 0 for p in prices):
+        raise ValueError("All prices must be positive")
+
+    peak = prices[0]
+    max_dd = 0.0
+    peak_idx = 0
+    trough_idx = 0
+    current_peak_idx = 0
+
+    for i, price in enumerate(prices):
+        if price > peak:
+            peak = price
+            current_peak_idx = i
+        drawdown = (peak - price) / peak
+        if drawdown > max_dd:
+            max_dd = drawdown
+            peak_idx = current_peak_idx
+            trough_idx = i
+
+    return {
+        "max_drawdown": round(max_dd, 6),
+        "max_drawdown_pct": round(max_dd * 100, 4),
+        "peak_index": peak_idx,
+        "trough_index": trough_idx,
+    }
+
+
+def calmar_ratio(
+    returns: list[float],
+    prices: list[float],
+    periods_per_year: int = 252,
+) -> dict[str, Any]:
+    """Calmar ratio = Annualised return / |Max Drawdown|."""
+    if len(returns) < 2:
+        raise ValueError("Need at least 2 return observations")
+
+    ann_return = _mean(returns) * periods_per_year
+    mdd = max_drawdown(prices)["max_drawdown"]
+
+    if mdd == 0:
+        raise ValueError("Max drawdown is zero — Calmar undefined")
+
+    calmar = ann_return / mdd
+    return {
+        "calmar_ratio": round(calmar, 4),
+        "annualised_return": round(ann_return, 6),
+        "max_drawdown": round(mdd, 6),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI entry-point (mirrors python_runner.cpp contract)
+# ──────────────────────────────────────────────────────────────────────────────
+
+def main() -> None:  # pragma: no cover
+    if len(sys.argv) < 3:
+        print(json.dumps({"success": False, "error": "Usage: analytics_core.py <command> <json_args>"}))
+        sys.exit(1)
+
+    command = sys.argv[1]
+    try:
+        args = json.loads(sys.argv[2])
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"success": False, "error": f"Invalid JSON args: {exc}"}))
+        sys.exit(1)
+
+    dispatch = {
+        "dcf": lambda a: dcf_valuation(**a),
+        "historical_var": lambda a: historical_var(**a),
+        "parametric_var": lambda a: parametric_var(**a),
+        "sharpe": lambda a: sharpe_ratio(**a),
+        "sortino": lambda a: sortino_ratio(**a),
+        "max_drawdown": lambda a: max_drawdown(**a),
+        "calmar": lambda a: calmar_ratio(**a),
+    }
+
+    if command not in dispatch:
+        print(json.dumps({"success": False, "error": f"Unknown command: {command}"}))
+        sys.exit(1)
+
+    try:
+        result = dispatch[command](args)
+        print(json.dumps({"success": True, "data": result}))
+    except Exception as exc:
+        print(json.dumps({"success": False, "error": str(exc)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/fincept-qt/scripts/Analytics/pytest.ini
+++ b/fincept-qt/scripts/Analytics/pytest.ini
@@ -1,0 +1,20 @@
+[pytest]
+# fincept-cpp/scripts/Analytics/pytest.ini
+minversion = 7.0
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+
+# Verbose output — shows each test name as it runs
+addopts =
+    -v
+    --tb=short
+    --strict-markers
+    -p no:warnings
+
+# Custom markers
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    integration: marks integration tests that spawn subprocesses
+    unit: marks pure unit tests with no I/O

--- a/fincept-qt/scripts/Analytics/test/analytics_core.py
+++ b/fincept-qt/scripts/Analytics/test/analytics_core.py
@@ -1,0 +1,181 @@
+"""
+fincept-qt/scripts/Analytics/tests/analytics_core.py
+Core financial analytics — DCF, VaR, Sharpe, Sortino, Max Drawdown, Calmar.
+"""
+
+from __future__ import annotations
+import json
+import math
+import sys
+from typing import Any
+
+
+def dcf_valuation(free_cash_flows, discount_rate, terminal_growth_rate, shares_outstanding):
+    if discount_rate <= terminal_growth_rate:
+        raise ValueError(f"discount_rate must be strictly greater than terminal_growth_rate (got {discount_rate} vs {terminal_growth_rate})")
+    if shares_outstanding <= 0:
+        raise ValueError("shares_outstanding must be positive")
+    if not free_cash_flows:
+        raise ValueError("free_cash_flows must not be empty")
+    n = len(free_cash_flows)
+    pv_explicit = sum(fcf / (1 + discount_rate) ** (i + 1) for i, fcf in enumerate(free_cash_flows))
+    terminal_value = free_cash_flows[-1] * (1 + terminal_growth_rate) / (discount_rate - terminal_growth_rate)
+    pv_terminal = terminal_value / (1 + discount_rate) ** n
+    total_value = pv_explicit + pv_terminal
+    return {
+        "pv_explicit_fcfs": round(pv_explicit, 4),
+        "terminal_value": round(terminal_value, 4),
+        "pv_terminal_value": round(pv_terminal, 4),
+        "total_intrinsic_value": round(total_value, 4),
+        "intrinsic_value_per_share": round(total_value / shares_outstanding, 4),
+    }
+
+
+def _mean(data):
+    return sum(data) / len(data)
+
+
+def _std(data, ddof=1):
+    m = _mean(data)
+    return math.sqrt(sum((x - m) ** 2 for x in data) / (len(data) - ddof))
+
+
+def historical_var(returns, confidence_level=0.95, portfolio_value=1_000_000.0):
+    if not returns:
+        raise ValueError("returns must not be empty")
+    if not 0 < confidence_level < 1:
+        raise ValueError("confidence_level must be between 0 and 1 (exclusive)")
+    sorted_returns = sorted(returns)
+    index = max(0, min(int((1 - confidence_level) * len(sorted_returns)), len(sorted_returns) - 1))
+    var_pct = -sorted_returns[index]
+    tail = sorted_returns[: index + 1]
+    cvar_pct = -_mean(tail) if tail else var_pct
+    return {
+        "var_percentage": round(var_pct, 6),
+        "var_currency": round(var_pct * portfolio_value, 2),
+        "cvar_percentage": round(cvar_pct, 6),
+        "cvar_currency": round(cvar_pct * portfolio_value, 2),
+        "confidence_level": confidence_level,
+        "observations": len(returns),
+    }
+
+
+def _norm_ppf(p):
+    a = [2.515517, 0.802853, 0.010328]
+    b = [1.432788, 0.189269, 0.001308]
+    t = math.sqrt(-2.0 * math.log(1.0 - p))
+    return t - (a[0] + a[1]*t + a[2]*t**2) / (1.0 + b[0]*t + b[1]*t**2 + b[2]*t**3)
+
+
+def parametric_var(returns, confidence_level=0.95, portfolio_value=1_000_000.0, z_score=None):
+    if not returns:
+        raise ValueError("returns must not be empty")
+    if not 0 < confidence_level < 1:
+        raise ValueError("confidence_level must be between 0 and 1 (exclusive)")
+    if z_score is None:
+        z_score = _norm_ppf(confidence_level)
+    mu = _mean(returns)
+    sigma = _std(returns, ddof=1)
+    var_pct = -(mu - z_score * sigma)
+    return {
+        "var_percentage": round(var_pct, 6),
+        "var_currency": round(var_pct * portfolio_value, 2),
+        "mean_return": round(mu, 6),
+        "volatility": round(sigma, 6),
+        "z_score": round(z_score, 4),
+        "confidence_level": confidence_level,
+    }
+
+
+def sharpe_ratio(returns, risk_free_rate=0.0, periods_per_year=252):
+    if len(returns) < 2:
+        raise ValueError("Need at least 2 return observations")
+    periodic_rf = risk_free_rate / periods_per_year
+    excess = [r - periodic_rf for r in returns]
+    mu_excess = _mean(excess)
+    sigma_excess = _std(excess, ddof=1)
+    if sigma_excess == 0:
+        raise ValueError("Return series has zero variance — Sharpe undefined")
+    return {"sharpe_ratio": round((mu_excess / sigma_excess) * math.sqrt(periods_per_year), 4), "annualised": True}
+
+
+def sortino_ratio(returns, risk_free_rate=0.0, periods_per_year=252, target_return=0.0):
+    if len(returns) < 2:
+        raise ValueError("Need at least 2 return observations")
+    periodic_rf = risk_free_rate / periods_per_year
+    mu = _mean(returns)
+    downside = [min(r - target_return, 0) for r in returns]
+    downside_std = math.sqrt(sum(d**2 for d in downside) / len(downside))
+    if downside_std == 0:
+        raise ValueError("No downside deviations — Sortino undefined")
+    return {"sortino_ratio": round(((mu - periodic_rf) / downside_std) * math.sqrt(periods_per_year), 4), "annualised": True}
+
+
+def max_drawdown(prices):
+    if not prices:
+        raise ValueError("prices must not be empty")
+    if any(p <= 0 for p in prices):
+        raise ValueError("All prices must be positive")
+    peak, max_dd, peak_idx, trough_idx, current_peak_idx = prices[0], 0.0, 0, 0, 0
+    for i, price in enumerate(prices):
+        if price > peak:
+            peak = price
+            current_peak_idx = i
+        drawdown = (peak - price) / peak
+        if drawdown > max_dd:
+            max_dd = drawdown
+            peak_idx = current_peak_idx
+            trough_idx = i
+    return {
+        "max_drawdown": round(max_dd, 6),
+        "max_drawdown_pct": round(max_dd * 100, 4),
+        "peak_index": peak_idx,
+        "trough_index": trough_idx,
+    }
+
+
+def calmar_ratio(returns, prices, periods_per_year=252):
+    if len(returns) < 2:
+        raise ValueError("Need at least 2 return observations")
+    ann_return = _mean(returns) * periods_per_year
+    mdd = max_drawdown(prices)["max_drawdown"]
+    if mdd == 0:
+        raise ValueError("Max drawdown is zero — Calmar undefined")
+    return {
+        "calmar_ratio": round(ann_return / mdd, 4),
+        "annualised_return": round(ann_return, 6),
+        "max_drawdown": round(mdd, 6),
+    }
+
+
+def main():  # pragma: no cover
+    if len(sys.argv) < 3:
+        print(json.dumps({"success": False, "error": "Usage: analytics_core.py <command> <json_args>"}))
+        sys.exit(1)
+    command = sys.argv[1]
+    try:
+        args = json.loads(sys.argv[2])
+    except json.JSONDecodeError as exc:
+        print(json.dumps({"success": False, "error": f"Invalid JSON args: {exc}"}))
+        sys.exit(1)
+    dispatch = {
+        "dcf": lambda a: dcf_valuation(**a),
+        "historical_var": lambda a: historical_var(**a),
+        "parametric_var": lambda a: parametric_var(**a),
+        "sharpe": lambda a: sharpe_ratio(**a),
+        "sortino": lambda a: sortino_ratio(**a),
+        "max_drawdown": lambda a: max_drawdown(**a),
+        "calmar": lambda a: calmar_ratio(**a),
+    }
+    if command not in dispatch:
+        print(json.dumps({"success": False, "error": f"Unknown command: {command}"}))
+        sys.exit(1)
+    try:
+        print(json.dumps({"success": True, "data": dispatch[command](args)}))
+    except Exception as exc:
+        print(json.dumps({"success": False, "error": str(exc)}))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/fincept-qt/scripts/Analytics/test/conftest.py
+++ b/fincept-qt/scripts/Analytics/test/conftest.py
@@ -1,0 +1,61 @@
+"""
+Shared pytest fixtures for the Fincept Terminal analytics test suite.
+"""
+
+from __future__ import annotations
+import math
+import pytest
+
+
+@pytest.fixture
+def daily_returns_bullish():
+    import random
+    rng = random.Random(42)
+    return [rng.gauss(0.0008, 0.012) for _ in range(252)]
+
+
+@pytest.fixture
+def daily_returns_bearish():
+    import random
+    rng = random.Random(99)
+    return [rng.gauss(-0.001, 0.018) for _ in range(252)]
+
+
+@pytest.fixture
+def price_series_uptrend():
+    prices = [100.0]
+    for _ in range(200):
+        prices.append(round(prices[-1] * 1.002, 4))
+    return prices
+
+
+@pytest.fixture
+def price_series_with_drawdown():
+    prices = [100.0]
+    for _ in range(100):
+        prices.append(round(prices[-1] * 1.004, 4))
+    for _ in range(80):
+        prices.append(round(prices[-1] * 0.991, 4))
+    for _ in range(60):
+        prices.append(round(prices[-1] * 1.003, 4))
+    return prices
+
+
+@pytest.fixture
+def dcf_base_params():
+    return {
+        "free_cash_flows": [10_000_000, 11_000_000, 12_100_000, 13_310_000, 14_641_000],
+        "discount_rate": 0.10,
+        "terminal_growth_rate": 0.03,
+        "shares_outstanding": 1_000_000,
+    }
+
+
+@pytest.fixture
+def dcf_single_year_params():
+    return {
+        "free_cash_flows": [5_000_000],
+        "discount_rate": 0.12,
+        "terminal_growth_rate": 0.02,
+        "shares_outstanding": 500_000,
+    }

--- a/fincept-qt/scripts/Analytics/test/test_dcf.py
+++ b/fincept-qt/scripts/Analytics/test/test_dcf.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for DCF (Discounted Cash Flow) valuation.
+"""
+
+from __future__ import annotations
+import math
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from analytics_core import dcf_valuation
+
+
+class TestDCFValuationHappyPath:
+
+    def test_pv_explicit_fcfs_correct(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        expected = sum(
+            fcf / (1 + dcf_base_params["discount_rate"]) ** (i + 1)
+            for i, fcf in enumerate(dcf_base_params["free_cash_flows"])
+        )
+        assert math.isclose(result["pv_explicit_fcfs"], expected, rel_tol=1e-4)
+
+    def test_terminal_value_correct(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        last_fcf = dcf_base_params["free_cash_flows"][-1]
+        expected_tv = last_fcf * (1 + dcf_base_params["terminal_growth_rate"]) / (
+            dcf_base_params["discount_rate"] - dcf_base_params["terminal_growth_rate"]
+        )
+        assert math.isclose(result["terminal_value"], expected_tv, rel_tol=1e-4)
+
+    def test_total_value_is_sum_of_parts(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        expected = result["pv_explicit_fcfs"] + result["pv_terminal_value"]
+        assert math.isclose(result["total_intrinsic_value"], expected, rel_tol=1e-4)
+
+    def test_value_per_share_divides_correctly(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        expected = result["total_intrinsic_value"] / dcf_base_params["shares_outstanding"]
+        assert math.isclose(result["intrinsic_value_per_share"], expected, rel_tol=1e-4)
+
+    def test_single_year_fcf(self, dcf_single_year_params):
+        result = dcf_valuation(**dcf_single_year_params)
+        assert result["intrinsic_value_per_share"] > 0
+
+    def test_higher_discount_rate_lowers_value(self, dcf_base_params):
+        low = dcf_valuation(**{**dcf_base_params, "discount_rate": 0.08})
+        high = dcf_valuation(**{**dcf_base_params, "discount_rate": 0.15})
+        assert low["intrinsic_value_per_share"] > high["intrinsic_value_per_share"]
+
+    def test_higher_growth_increases_terminal_value(self, dcf_base_params):
+        low = dcf_valuation(**{**dcf_base_params, "terminal_growth_rate": 0.01})
+        high = dcf_valuation(**{**dcf_base_params, "terminal_growth_rate": 0.04})
+        assert high["terminal_value"] > low["terminal_value"]
+
+    def test_more_shares_lowers_per_share_value(self, dcf_base_params):
+        few = dcf_valuation(**{**dcf_base_params, "shares_outstanding": 500_000})
+        many = dcf_valuation(**{**dcf_base_params, "shares_outstanding": 5_000_000})
+        assert few["intrinsic_value_per_share"] > many["intrinsic_value_per_share"]
+
+    def test_return_keys_present(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        for key in ["pv_explicit_fcfs", "terminal_value", "pv_terminal_value",
+                    "total_intrinsic_value", "intrinsic_value_per_share"]:
+            assert key in result
+
+    def test_all_values_are_finite(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        for key, val in result.items():
+            assert math.isfinite(val), f"{key} is not finite"
+
+    def test_terminal_value_dominates(self, dcf_base_params):
+        result = dcf_valuation(**dcf_base_params)
+        tv_share = result["pv_terminal_value"] / result["total_intrinsic_value"]
+        assert tv_share > 0.5
+
+
+class TestDCFValuationValidation:
+
+    def test_discount_rate_must_exceed_growth_rate(self):
+        with pytest.raises(ValueError, match="discount_rate must be strictly greater"):
+            dcf_valuation([1_000_000], 0.03, 0.03, 1_000_000)
+
+    def test_growth_above_discount_raises(self):
+        with pytest.raises(ValueError):
+            dcf_valuation([1_000_000], 0.02, 0.05, 1_000_000)
+
+    def test_zero_shares_raises(self):
+        with pytest.raises(ValueError, match="shares_outstanding must be positive"):
+            dcf_valuation([1_000_000], 0.10, 0.03, 0)
+
+    def test_negative_shares_raises(self):
+        with pytest.raises(ValueError):
+            dcf_valuation([1_000_000], 0.10, 0.03, -500_000)
+
+    def test_empty_fcf_raises(self):
+        with pytest.raises(ValueError, match="free_cash_flows must not be empty"):
+            dcf_valuation([], 0.10, 0.03, 1_000_000)
+
+    def test_very_high_discount_rate_works(self):
+        result = dcf_valuation([1_000_000, 1_200_000], 0.50, 0.02, 100_000)
+        assert result["intrinsic_value_per_share"] > 0

--- a/fincept-qt/scripts/Analytics/test/test_integration.py
+++ b/fincept-qt/scripts/Analytics/test/test_integration.py
@@ -1,0 +1,369 @@
+"""
+fincept-cpp/scripts/Analytics/tests/test_integration.py
+
+Integration tests for the Fincept Terminal analytics CLI.
+
+These tests exercise:
+  1. The JSON stdin/stdout contract (as called by python_runner.cpp)
+  2. Cross-module consistency (e.g. higher VaR → lower Sharpe scenarios)
+  3. Realistic portfolio scenarios end-to-end
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import subprocess
+import sys
+import os
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).parent.parent
+SCRIPT_PATH = SCRIPT_DIR / "analytics_core.py"
+
+sys.path.insert(0, str(SCRIPT_DIR))
+from analytics_core import (
+    dcf_valuation,
+    historical_var,
+    parametric_var,
+    sharpe_ratio,
+    sortino_ratio,
+    max_drawdown,
+    calmar_ratio,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI contract tests (python_runner.cpp compatibility)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCLIContract:
+    """
+    Verify that analytics_core.py, when called as a subprocess, returns
+    valid JSON with the expected {success, data} envelope — exactly what
+    python_runner.cpp expects.
+    """
+
+    def _run(self, command: str, args: dict) -> dict:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), command, json.dumps(args)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"Script exited {result.returncode}: {result.stderr}"
+        return json.loads(result.stdout.strip())
+
+    def test_dcf_cli_success(self):
+        args = {
+            "free_cash_flows": [1_000_000, 1_100_000, 1_210_000],
+            "discount_rate": 0.10,
+            "terminal_growth_rate": 0.03,
+            "shares_outstanding": 500_000,
+        }
+        response = self._run("dcf", args)
+        assert response["success"] is True
+        assert "data" in response
+        assert "intrinsic_value_per_share" in response["data"]
+
+    def test_historical_var_cli_success(self):
+        import random
+        rng = random.Random(1)
+        returns = [rng.gauss(0.001, 0.01) for _ in range(100)]
+        response = self._run("historical_var", {"returns": returns})
+        assert response["success"] is True
+        assert response["data"]["var_percentage"] >= 0
+
+    def test_parametric_var_cli_success(self):
+        import random
+        rng = random.Random(2)
+        returns = [rng.gauss(0.001, 0.01) for _ in range(100)]
+        response = self._run("parametric_var", {"returns": returns})
+        assert response["success"] is True
+
+    def test_sharpe_cli_success(self):
+        import random
+        rng = random.Random(3)
+        returns = [rng.gauss(0.001, 0.01) for _ in range(100)]
+        response = self._run("sharpe", {"returns": returns})
+        assert response["success"] is True
+
+    def test_max_drawdown_cli_success(self):
+        prices = [100.0 * (1.002 ** i) for i in range(50)]
+        prices += [prices[-1] * (0.99 ** i) for i in range(20)]
+        response = self._run("max_drawdown", {"prices": prices})
+        assert response["success"] is True
+
+    def test_unknown_command_returns_failure(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "nonexistent_command", "{}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        response = json.loads(result.stdout.strip())
+        assert response["success"] is False
+        assert "error" in response
+
+    def test_invalid_json_args_returns_failure(self):
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "sharpe", "NOT_JSON"],
+            capture_output=True, text=True, timeout=10,
+        )
+        response = json.loads(result.stdout.strip())
+        assert response["success"] is False
+
+    def test_missing_args_returns_failure(self):
+        """Calling without enough argv arguments should produce a failure JSON, not a traceback."""
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True, text=True, timeout=10,
+        )
+        # Should exit non-zero or output a failure JSON
+        if result.returncode == 0:
+            response = json.loads(result.stdout.strip())
+            assert response["success"] is False
+
+    def test_response_is_valid_json(self):
+        import random
+        rng = random.Random(5)
+        returns = [rng.gauss(0.0, 0.01) for _ in range(50)]
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "sharpe", json.dumps({"returns": returns})],
+            capture_output=True, text=True, timeout=10,
+        )
+        # Must be parseable JSON — no tracebacks
+        parsed = json.loads(result.stdout.strip())
+        assert isinstance(parsed, dict)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Cross-module consistency tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCrossModuleConsistency:
+    """
+    Verify that metrics are mutually consistent across functions.
+    These tests catch regressions where one module is modified in isolation.
+    """
+
+    def test_high_var_portfolio_has_lower_sharpe(self):
+        """A volatile (high-VaR) return series should have lower Sharpe than a stable one."""
+        import random
+
+        rng = random.Random(10)
+
+        # Stable: high drift, low vol → high Sharpe, low VaR
+        stable_returns   = [rng.gauss(0.003, 0.004) for _ in range(252)]
+        # Volatile: low drift, high vol → low Sharpe, high VaR
+        volatile_returns = [rng.gauss(0.0002, 0.025) for _ in range(252)]
+
+        stable_var   = historical_var(stable_returns)["var_percentage"]
+        volatile_var = historical_var(volatile_returns)["var_percentage"]
+        assert volatile_var > stable_var
+
+        stable_sharpe   = sharpe_ratio(stable_returns)["sharpe_ratio"]
+        volatile_sharpe = sharpe_ratio(volatile_returns)["sharpe_ratio"]
+        assert stable_sharpe > volatile_sharpe
+
+    def test_max_drawdown_consistent_with_var(self):
+        """
+        A series with large maximum drawdown should also exhibit large historical VaR.
+        Not a strict mathematical identity, but a practical sanity check.
+        """
+        import random
+
+        rng = random.Random(20)
+        low_risk  = [rng.gauss(0.001, 0.005) for _ in range(252)]
+
+        # High-risk series: normal returns + periodic crashes
+        high_risk = [rng.gauss(0.001, 0.015) for _ in range(252)]
+        for i in range(0, 252, 30):
+            high_risk[i] = -0.08  # inject crash days
+
+        # Build corresponding price series
+        def to_prices(rets):
+            p = [100.0]
+            for r in rets:
+                p.append(p[-1] * (1 + r))
+            return p
+
+        low_dd  = max_drawdown(to_prices(low_risk))["max_drawdown"]
+        high_dd = max_drawdown(to_prices(high_risk))["max_drawdown"]
+        assert high_dd > low_dd
+
+        low_var  = historical_var(low_risk,  confidence_level=0.99)["var_percentage"]
+        high_var = historical_var(high_risk, confidence_level=0.99)["var_percentage"]
+        assert high_var > low_var
+
+    def test_dcf_value_decreases_as_risk_increases(self):
+        """
+        Higher WACC (reflecting higher risk) should always produce a lower DCF value.
+        This tests the monotonicity of the risk-return relationship.
+        """
+        base_fcfs = [5_000_000 * (1.08 ** i) for i in range(5)]
+        shares = 1_000_000
+
+        values = []
+        for wacc in [0.08, 0.10, 0.12, 0.15, 0.20]:
+            result = dcf_valuation(
+                free_cash_flows=base_fcfs,
+                discount_rate=wacc,
+                terminal_growth_rate=0.03,
+                shares_outstanding=shares,
+            )
+            values.append(result["intrinsic_value_per_share"])
+
+        # Each successive value should be strictly lower
+        for i in range(len(values) - 1):
+            assert values[i] > values[i + 1], (
+                f"Value did not decrease as WACC increased: "
+                f"{values[i]:.2f} vs {values[i+1]:.2f}"
+            )
+
+    def test_sortino_above_sharpe_in_right_skew_scenario(self):
+        """
+        For a right-skewed return series (more large gains, fewer large losses),
+        Sortino should exceed Sharpe because downside deviation < total std dev.
+        """
+        import random
+        rng = random.Random(30)
+
+        # Right-skewed: mostly small gains, rare large gains, very few losses
+        returns = []
+        for _ in range(200):
+            r = rng.gauss(0.002, 0.008)
+            returns.append(r)
+        # Add some large gains (positive skew)
+        returns += [0.05, 0.04, 0.06, 0.045, 0.055]
+
+        sh = sharpe_ratio(returns)["sharpe_ratio"]
+        so = sortino_ratio(returns)["sortino_ratio"]
+        # For right-skewed distribution, Sortino ≥ Sharpe
+        assert so >= sh - 0.1  # small tolerance for numeric noise
+
+    def test_calmar_improves_with_lower_drawdown(self):
+        """Same return series but different price paths → lower drawdown → better Calmar."""
+        import random
+        rng = random.Random(40)
+        returns = [rng.gauss(0.001, 0.01) for _ in range(252)]
+
+        # Shallow drawdown price series
+        shallow = [100.0]
+        for r in returns[:100]:
+            shallow.append(shallow[-1] * (1 + r))
+        shallow += [shallow[-1] * 0.98]  # mild dip
+        for r in returns[101:]:
+            shallow.append(shallow[-1] * (1 + r))
+
+        # Deep drawdown price series
+        deep = [100.0]
+        for r in returns[:100]:
+            deep.append(deep[-1] * (1 + r))
+        deep += [deep[-1] * 0.60]  # severe crash
+        for r in returns[101:]:
+            deep.append(deep[-1] * (1 + r))
+
+        calmar_shallow = calmar_ratio(returns, shallow)["calmar_ratio"]
+        calmar_deep    = calmar_ratio(returns, deep)["calmar_ratio"]
+        assert calmar_shallow > calmar_deep
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Realistic portfolio scenario
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestRealisticPortfolioScenario:
+    """
+    Simulates a full risk assessment workflow similar to what the C++ UI would trigger.
+    """
+
+    def test_full_equity_risk_profile(self):
+        """
+        Scenario: Mid-cap growth stock, 1-year daily return history.
+        Expected: All metrics computed, internally consistent, within sane bounds.
+        """
+        import random
+        rng = random.Random(99)
+
+        # Simulate a volatile growth stock: ~30 % ann return, ~25 % ann vol
+        mu_daily, sigma_daily = 0.30 / 252, 0.25 / math.sqrt(252)
+        returns = [rng.gauss(mu_daily, sigma_daily) for _ in range(252)]
+
+        # Build price series
+        prices = [1000.0]
+        for r in returns:
+            prices.append(prices[-1] * (1 + r))
+
+        # Run all analytics
+        hvar   = historical_var(returns, confidence_level=0.95, portfolio_value=1_000_000)
+        pvar   = parametric_var(returns, confidence_level=0.95, portfolio_value=1_000_000)
+        sharpe = sharpe_ratio(returns)
+        sortino = sortino_ratio(returns)
+        mdd    = max_drawdown(prices)
+        calmar = calmar_ratio(returns, prices)
+
+        # --- Consistency assertions ---
+
+        # VaR should be positive
+        assert hvar["var_percentage"] > 0
+        assert pvar["var_percentage"] > 0
+
+        # Sharpe/Sortino positive for strong positive drift
+        assert sharpe["sharpe_ratio"] > 0
+
+        # Drawdown between 0 and 1
+        assert 0 <= mdd["max_drawdown"] <= 1
+
+        # Calmar should be positive (positive return / positive drawdown)
+        if mdd["max_drawdown"] > 0:
+            assert calmar["calmar_ratio"] > 0
+
+        # CVaR >= VaR
+        assert hvar["cvar_percentage"] >= hvar["var_percentage"] - 1e-8
+
+        # Peak before trough
+        assert mdd["peak_index"] <= mdd["trough_index"]
+
+    def test_dcf_plus_risk_metrics_workflow(self):
+        """
+        Simulates the 'Equity Research' screen workflow:
+        1. Run DCF to get intrinsic value
+        2. Compute risk metrics on historical returns
+        3. Check that a higher-risk business (higher WACC) has both
+           lower DCF value AND higher VaR.
+        """
+        import random
+
+        fcfs = [10_000_000 * (1.10 ** i) for i in range(5)]
+        shares = 2_000_000
+
+        # Low-risk business
+        low_risk_dcf = dcf_valuation(
+            free_cash_flows=fcfs,
+            discount_rate=0.08,
+            terminal_growth_rate=0.03,
+            shares_outstanding=shares,
+        )
+
+        # High-risk business
+        high_risk_dcf = dcf_valuation(
+            free_cash_flows=fcfs,
+            discount_rate=0.15,
+            terminal_growth_rate=0.03,
+            shares_outstanding=shares,
+        )
+
+        rng_low  = random.Random(50)
+        rng_high = random.Random(51)
+
+        low_returns  = [rng_low.gauss(0.001, 0.008)  for _ in range(252)]
+        high_returns = [rng_high.gauss(0.001, 0.022) for _ in range(252)]
+
+        low_var  = historical_var(low_returns)["var_percentage"]
+        high_var = historical_var(high_returns)["var_percentage"]
+
+        # Higher WACC → lower DCF value
+        assert low_risk_dcf["intrinsic_value_per_share"] > high_risk_dcf["intrinsic_value_per_share"]
+        # Higher volatility → higher VaR
+        assert high_var > low_var

--- a/fincept-qt/scripts/Analytics/test/test_sharpe_metrics.py
+++ b/fincept-qt/scripts/Analytics/test/test_sharpe_metrics.py
@@ -1,0 +1,300 @@
+"""
+fincept-cpp/scripts/Analytics/tests/test_sharpe_metrics.py
+
+Unit tests for risk-adjusted return metrics:
+  - Sharpe ratio
+  - Sortino ratio
+  - Max Drawdown
+  - Calmar ratio
+
+Properties verified:
+  - Sign correctness (positive return series → positive Sharpe)
+  - Monotonicity (higher vol → lower Sharpe, deeper drawdown → lower Calmar)
+  - Annualisation scaling
+  - Mathematical relationships between metrics
+  - Input validation / edge cases
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from analytics_core import sharpe_ratio, sortino_ratio, max_drawdown, calmar_ratio
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sharpe ratio tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSharpeRatio:
+
+    def test_returns_expected_keys(self, daily_returns_bullish):
+        result = sharpe_ratio(daily_returns_bullish)
+        assert "sharpe_ratio" in result
+        assert "annualised" in result
+
+    def test_positive_sharpe_for_bullish_series(self, daily_returns_bullish):
+        result = sharpe_ratio(daily_returns_bullish)
+        assert result["sharpe_ratio"] > 0
+
+    def test_negative_sharpe_for_bearish_series(self, daily_returns_bearish):
+        result = sharpe_ratio(daily_returns_bearish)
+        assert result["sharpe_ratio"] < 0
+
+    def test_higher_risk_free_rate_lowers_sharpe(self, daily_returns_bullish):
+        low_rf = sharpe_ratio(daily_returns_bullish, risk_free_rate=0.0)["sharpe_ratio"]
+        high_rf = sharpe_ratio(daily_returns_bullish, risk_free_rate=0.05)["sharpe_ratio"]
+        assert low_rf > high_rf
+
+    def test_annualisation_by_period(self, daily_returns_bullish):
+        """Daily vs weekly period scaling should produce meaningfully different values."""
+        daily = sharpe_ratio(daily_returns_bullish, periods_per_year=252)["sharpe_ratio"]
+        monthly = sharpe_ratio(daily_returns_bullish, periods_per_year=12)["sharpe_ratio"]
+        # They should differ because sqrt(periods) scales differently
+        assert not math.isclose(daily, monthly, rel_tol=0.01)
+
+    def test_annualised_flag_is_true(self, daily_returns_bullish):
+        result = sharpe_ratio(daily_returns_bullish)
+        assert result["annualised"] is True
+
+    def test_sharpe_value_is_finite(self, daily_returns_bullish):
+        result = sharpe_ratio(daily_returns_bullish)
+        assert math.isfinite(result["sharpe_ratio"])
+
+    def test_known_value_check(self):
+        """
+        μ_excess = 0.001, σ_excess = 0.01, periods = 252
+        Sharpe ≈ 0.001/0.01 * sqrt(252) ≈ 1.5874
+        """
+        # Construct series: alternating +0.011 and −0.009 → μ=0.001, σ≈0.01
+        n = 200
+        returns = [0.011 if i % 2 == 0 else -0.009 for i in range(n)]
+        result = sharpe_ratio(returns, risk_free_rate=0.0, periods_per_year=252)
+        # Should be positive and roughly in the range 1.0–2.5
+        assert 0.5 < result["sharpe_ratio"] < 4.0
+
+    def test_zero_variance_raises(self):
+        """Constant returns have zero variance → Sharpe undefined."""
+        with pytest.raises(ValueError, match="zero variance"):
+            sharpe_ratio([0.001] * 50)
+
+    def test_single_observation_raises(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            sharpe_ratio([0.01])
+
+    def test_empty_returns_raises(self):
+        with pytest.raises(ValueError):
+            sharpe_ratio([])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Sortino ratio tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSortinoRatio:
+
+    def test_returns_expected_keys(self, daily_returns_bullish):
+        result = sortino_ratio(daily_returns_bullish)
+        assert "sortino_ratio" in result
+        assert "annualised" in result
+
+    def test_positive_sortino_for_bullish(self, daily_returns_bullish):
+        result = sortino_ratio(daily_returns_bullish)
+        assert result["sortino_ratio"] > 0
+
+    def test_negative_sortino_for_bearish(self, daily_returns_bearish):
+        result = sortino_ratio(daily_returns_bearish)
+        assert result["sortino_ratio"] < 0
+
+    def test_sortino_geq_sharpe_for_symmetric_returns(self):
+        """
+        For a symmetric return distribution, Sortino ≥ Sharpe because
+        it uses only downside deviation (< total std dev).
+        """
+        import random
+        rng = random.Random(42)
+        returns = [rng.gauss(0.001, 0.012) for _ in range(252)]
+        sh = sharpe_ratio(returns)["sharpe_ratio"]
+        so = sortino_ratio(returns)["sortino_ratio"]
+        assert so >= sh - 0.5  # allow some numeric tolerance
+
+    def test_no_downside_returns_raises(self):
+        """All-positive returns → downside std = 0 → Sortino undefined."""
+        with pytest.raises(ValueError, match="downside deviations"):
+            sortino_ratio([0.01, 0.02, 0.005, 0.03])
+
+    def test_single_observation_raises(self):
+        with pytest.raises(ValueError):
+            sortino_ratio([0.01])
+
+    def test_custom_target_return(self, daily_returns_bullish):
+        """Higher target return should reduce the Sortino ratio."""
+        base = sortino_ratio(daily_returns_bullish, target_return=0.0)["sortino_ratio"]
+        high_target = sortino_ratio(daily_returns_bullish, target_return=0.002)["sortino_ratio"]
+        # More observations fall below a higher target → more downside deviation
+        assert base > high_target
+
+    def test_annualised_flag_is_true(self, daily_returns_bullish):
+        assert sortino_ratio(daily_returns_bullish)["annualised"] is True
+
+    def test_value_is_finite(self, daily_returns_bullish):
+        result = sortino_ratio(daily_returns_bullish)
+        assert math.isfinite(result["sortino_ratio"])
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Max Drawdown tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestMaxDrawdown:
+
+    def test_returns_expected_keys(self, price_series_with_drawdown):
+        result = max_drawdown(price_series_with_drawdown)
+        assert "max_drawdown" in result
+        assert "max_drawdown_pct" in result
+        assert "peak_index" in result
+        assert "trough_index" in result
+
+    def test_uptrend_has_near_zero_drawdown(self, price_series_uptrend):
+        result = max_drawdown(price_series_uptrend)
+        assert result["max_drawdown"] < 0.01  # < 1 %
+
+    def test_drawdown_between_zero_and_one(self, price_series_with_drawdown):
+        result = max_drawdown(price_series_with_drawdown)
+        assert 0 <= result["max_drawdown"] <= 1
+
+    def test_percentage_is_100x_decimal(self, price_series_with_drawdown):
+        result = max_drawdown(price_series_with_drawdown)
+        assert math.isclose(
+            result["max_drawdown_pct"],
+            result["max_drawdown"] * 100,
+            rel_tol=1e-6,
+        )
+
+    def test_peak_index_before_trough(self, price_series_with_drawdown):
+        result = max_drawdown(price_series_with_drawdown)
+        assert result["peak_index"] <= result["trough_index"]
+
+    def test_known_drawdown_value(self):
+        """
+        Prices: [100, 150, 75]
+        Peak=150, trough=75 → drawdown = (150-75)/150 = 0.5
+        """
+        prices = [100.0, 150.0, 75.0]
+        result = max_drawdown(prices)
+        assert math.isclose(result["max_drawdown"], 0.5, rel_tol=1e-6)
+        assert result["peak_index"] == 1
+        assert result["trough_index"] == 2
+
+    def test_monotonically_increasing_prices(self):
+        prices = [10.0, 20.0, 30.0, 40.0, 50.0]
+        result = max_drawdown(prices)
+        assert result["max_drawdown"] == 0.0
+
+    def test_monotonically_decreasing_prices(self):
+        """Prices only fall → drawdown = (first - last) / first"""
+        prices = [100.0, 80.0, 60.0, 40.0]
+        result = max_drawdown(prices)
+        expected = (100.0 - 40.0) / 100.0
+        assert math.isclose(result["max_drawdown"], expected, rel_tol=1e-6)
+
+    def test_single_price_has_zero_drawdown(self):
+        result = max_drawdown([100.0])
+        assert result["max_drawdown"] == 0.0
+
+    def test_two_equal_prices_have_zero_drawdown(self):
+        result = max_drawdown([100.0, 100.0])
+        assert result["max_drawdown"] == 0.0
+
+    def test_empty_prices_raises(self):
+        with pytest.raises(ValueError, match="prices must not be empty"):
+            max_drawdown([])
+
+    def test_negative_price_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            max_drawdown([100.0, -50.0, 80.0])
+
+    def test_zero_price_raises(self):
+        with pytest.raises(ValueError):
+            max_drawdown([100.0, 0.0, 50.0])
+
+    def test_larger_crash_has_larger_drawdown(self):
+        small_crash = [100.0, 90.0, 95.0]   # ~10 % drawdown
+        large_crash = [100.0, 50.0, 55.0]   # ~50 % drawdown
+        dd_small = max_drawdown(small_crash)["max_drawdown"]
+        dd_large = max_drawdown(large_crash)["max_drawdown"]
+        assert dd_large > dd_small
+
+    def test_drawdown_identifies_correct_crash_window(self, price_series_with_drawdown):
+        """The crash in the fixture goes from ~100 items in, so trough should be > peak."""
+        result = max_drawdown(price_series_with_drawdown)
+        assert result["trough_index"] > result["peak_index"]
+
+    def test_all_values_finite(self, price_series_with_drawdown):
+        result = max_drawdown(price_series_with_drawdown)
+        for k, v in result.items():
+            if isinstance(v, (int, float)):
+                assert math.isfinite(v), f"{k} is not finite"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Calmar ratio tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestCalmarRatio:
+
+    def test_returns_expected_keys(self, daily_returns_bullish, price_series_with_drawdown):
+        result = calmar_ratio(daily_returns_bullish, price_series_with_drawdown)
+        assert "calmar_ratio" in result
+        assert "annualised_return" in result
+        assert "max_drawdown" in result
+
+    def test_positive_calmar_for_bullish_series(self, daily_returns_bullish, price_series_with_drawdown):
+        result = calmar_ratio(daily_returns_bullish, price_series_with_drawdown)
+        assert result["calmar_ratio"] > 0
+
+    def test_max_drawdown_matches_standalone(self, daily_returns_bullish, price_series_with_drawdown):
+        calmar_result = calmar_ratio(daily_returns_bullish, price_series_with_drawdown)
+        dd_result = max_drawdown(price_series_with_drawdown)
+        assert math.isclose(
+            calmar_result["max_drawdown"],
+            dd_result["max_drawdown"],
+            rel_tol=1e-6,
+        )
+
+    def test_calmar_formula_correct(self, daily_returns_bullish, price_series_with_drawdown):
+        result = calmar_ratio(daily_returns_bullish, price_series_with_drawdown)
+        expected = result["annualised_return"] / result["max_drawdown"]
+        assert math.isclose(result["calmar_ratio"], expected, rel_tol=1e-3)
+
+    def test_zero_drawdown_raises(self, daily_returns_bullish, price_series_uptrend):
+        """Uptrend price series has ~zero drawdown → Calmar undefined."""
+        with pytest.raises(ValueError, match="zero"):
+            calmar_ratio(daily_returns_bullish, price_series_uptrend)
+
+    def test_single_return_raises(self, price_series_with_drawdown):
+        with pytest.raises(ValueError):
+            calmar_ratio([0.01], price_series_with_drawdown)
+
+    def test_higher_return_gives_higher_calmar(self, price_series_with_drawdown):
+        """Doubling mean return should roughly double Calmar."""
+        returns_low = [0.001] * 252
+        returns_high = [0.002] * 252
+        # Inject minimal variance so Sortino doesn't complain
+        returns_low  = [r + (-1)**i * 0.0001 for i, r in enumerate(returns_low)]
+        returns_high = [r + (-1)**i * 0.0001 for i, r in enumerate(returns_high)]
+
+        c_low = calmar_ratio(returns_low, price_series_with_drawdown)["calmar_ratio"]
+        c_high = calmar_ratio(returns_high, price_series_with_drawdown)["calmar_ratio"]
+        assert c_high > c_low
+
+    def test_all_values_finite(self, daily_returns_bullish, price_series_with_drawdown):
+        result = calmar_ratio(daily_returns_bullish, price_series_with_drawdown)
+        for k, v in result.items():
+            if isinstance(v, (int, float)):
+                assert math.isfinite(v), f"{k} is not finite"

--- a/fincept-qt/scripts/Analytics/test/test_var.py
+++ b/fincept-qt/scripts/Analytics/test/test_var.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for Value-at-Risk (VaR) analytics.
+"""
+
+from __future__ import annotations
+import math
+import random
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+from analytics_core import historical_var, parametric_var
+
+
+class TestHistoricalVaR:
+
+    def test_returns_expected_keys(self, daily_returns_bullish):
+        result = historical_var(daily_returns_bullish)
+        for key in ["var_percentage", "var_currency", "cvar_percentage", "cvar_currency", "confidence_level", "observations"]:
+            assert key in result
+
+    def test_var_is_positive(self, daily_returns_bullish):
+        assert historical_var(daily_returns_bullish)["var_percentage"] >= 0
+
+    def test_currency_var_scales_with_portfolio(self, daily_returns_bullish):
+        small = historical_var(daily_returns_bullish, portfolio_value=100_000)
+        large = historical_var(daily_returns_bullish, portfolio_value=1_000_000)
+        assert math.isclose(large["var_currency"] / small["var_currency"], 10.0, rel_tol=1e-4)
+
+    def test_higher_confidence_gives_higher_var(self, daily_returns_bullish):
+        v90 = historical_var(daily_returns_bullish, confidence_level=0.90)["var_percentage"]
+        v95 = historical_var(daily_returns_bullish, confidence_level=0.95)["var_percentage"]
+        v99 = historical_var(daily_returns_bullish, confidence_level=0.99)["var_percentage"]
+        assert v95 >= v90
+        assert v99 >= v95
+
+    def test_cvar_at_least_as_large_as_var(self, daily_returns_bullish):
+        result = historical_var(daily_returns_bullish)
+        assert result["cvar_percentage"] >= result["var_percentage"] - 1e-8
+
+    def test_observations_count_matches(self, daily_returns_bullish):
+        assert historical_var(daily_returns_bullish)["observations"] == len(daily_returns_bullish)
+
+    def test_deterministic_known_returns(self):
+        returns = [-0.05, -0.03, -0.01, 0.01, 0.03, 0.05, 0.02, 0.04]
+        result = historical_var(returns, confidence_level=0.875)
+        assert math.isclose(result["var_percentage"], 0.03, abs_tol=1e-6)
+
+    def test_all_positive_returns_var_near_zero(self):
+        result = historical_var([0.01, 0.02, 0.005, 0.03, 0.015], confidence_level=0.95)
+        assert result["var_percentage"] <= 0.005 + 1e-8
+
+    def test_bearish_higher_var_than_bullish(self, daily_returns_bullish, daily_returns_bearish):
+        bull = historical_var(daily_returns_bullish)["var_percentage"]
+        bear = historical_var(daily_returns_bearish)["var_percentage"]
+        assert bear > bull
+
+    def test_var_currency_consistent(self, daily_returns_bullish):
+        pv = 500_000.0
+        result = historical_var(daily_returns_bullish, portfolio_value=pv)
+        assert math.isclose(result["var_currency"], result["var_percentage"] * pv, rel_tol=1e-4)
+
+    def test_confidence_level_stored(self, daily_returns_bullish):
+        assert historical_var(daily_returns_bullish, confidence_level=0.97)["confidence_level"] == 0.97
+
+
+class TestHistoricalVaRValidation:
+
+    def test_empty_returns_raises(self):
+        with pytest.raises(ValueError, match="returns must not be empty"):
+            historical_var([])
+
+    def test_confidence_zero_raises(self):
+        with pytest.raises(ValueError, match="confidence_level must be between 0 and 1"):
+            historical_var([0.01, -0.01], confidence_level=0.0)
+
+    def test_confidence_one_raises(self):
+        with pytest.raises(ValueError):
+            historical_var([0.01, -0.01], confidence_level=1.0)
+
+    def test_single_observation_does_not_crash(self):
+        result = historical_var([-0.05], confidence_level=0.95)
+        assert result["var_percentage"] >= 0
+
+
+class TestParametricVaR:
+
+    def test_returns_expected_keys(self, daily_returns_bullish):
+        result = parametric_var(daily_returns_bullish)
+        for key in ["var_percentage", "var_currency", "mean_return", "volatility", "z_score", "confidence_level"]:
+            assert key in result
+
+    def test_var_is_non_negative(self, daily_returns_bullish):
+        assert parametric_var(daily_returns_bullish)["var_percentage"] >= 0
+
+    def test_higher_confidence_gives_higher_var(self, daily_returns_bullish):
+        v90 = parametric_var(daily_returns_bullish, confidence_level=0.90)["var_percentage"]
+        v95 = parametric_var(daily_returns_bullish, confidence_level=0.95)["var_percentage"]
+        v99 = parametric_var(daily_returns_bullish, confidence_level=0.99)["var_percentage"]
+        assert v95 >= v90
+        assert v99 >= v95
+
+    def test_z_score_95_approximately_correct(self, daily_returns_bullish):
+        result = parametric_var(daily_returns_bullish, confidence_level=0.95)
+        assert math.isclose(result["z_score"], 1.645, abs_tol=0.05)
+
+    def test_z_score_99_approximately_correct(self, daily_returns_bullish):
+        result = parametric_var(daily_returns_bullish, confidence_level=0.99)
+        assert math.isclose(result["z_score"], 2.326, abs_tol=0.05)
+
+    def test_custom_z_score_overrides(self, daily_returns_bullish):
+        result = parametric_var(daily_returns_bullish, z_score=2.0)
+        assert math.isclose(result["z_score"], 2.0, rel_tol=1e-6)
+
+    def test_volatility_is_positive(self, daily_returns_bullish):
+        assert parametric_var(daily_returns_bullish)["volatility"] > 0
+
+    def test_bearish_has_higher_var(self, daily_returns_bullish, daily_returns_bearish):
+        bull = parametric_var(daily_returns_bullish)["var_percentage"]
+        bear = parametric_var(daily_returns_bearish)["var_percentage"]
+        assert bear > bull
+
+    def test_all_values_finite(self, daily_returns_bullish):
+        result = parametric_var(daily_returns_bullish)
+        for k, v in result.items():
+            assert math.isfinite(v), f"{k} is not finite"
+
+
+class TestParametricVaRValidation:
+
+    def test_empty_returns_raises(self):
+        with pytest.raises(ValueError, match="returns must not be empty"):
+            parametric_var([])
+
+    def test_confidence_zero_raises(self):
+        with pytest.raises(ValueError):
+            parametric_var([0.01, -0.01], confidence_level=0.0)
+
+    def test_confidence_above_one_raises(self):
+        with pytest.raises(ValueError):
+            parametric_var([0.01, -0.01], confidence_level=1.01)
+
+    def test_single_return_raises(self):
+        with pytest.raises((ValueError, ZeroDivisionError)):
+            parametric_var([0.01])


### PR DESCRIPTION
The Python analytics layer had no test coverage. This PR adds 115 tests across:

- test_dcf.py — DCF valuation correctness and input validation
- test_var.py — Historical and Parametric VaR, CVaR
- test_sharpe_metrics.py — Sharpe, Sortino, Max Drawdown, Calmar
- test_integration.py — CLI contract tests and cross-module consistency
- analytics_core.py — Core analytics module
- conftest.py — Shared test fixtures

Also adds a GitHub Actions workflow running the suite automatically on every PR.