### PR TITLE
fix(security): harden credential storage and Python subprocess env isolation

### DIFF
--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -1826,9 +1826,29 @@ target_link_libraries(FinceptTerminal PRIVATE
     OpenSSL::Crypto
 )
 
-# macOS: also link Security.framework for Keychain in SecureStorage
+# macOS: link Security.framework + CoreFoundation for SecItem API in SecureStorage
 if(APPLE)
-    target_link_libraries(FinceptTerminal PRIVATE "-framework Security")
+    target_link_libraries(FinceptTerminal PRIVATE "-framework Security" "-framework CoreFoundation")
+endif()
+
+# Linux: optionally link libsecret for cryptographically secure credential storage.
+# Without libsecret, SecureStorage falls back to XOR-obfuscated QSettings (insecure).
+# Install libsecret-1-dev (Debian/Ubuntu) or libsecret-devel (Fedora) before building.
+if(UNIX AND NOT APPLE)
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(LIBSECRET IMPORTED_TARGET libsecret-1)
+        if(LIBSECRET_FOUND)
+            target_link_libraries(FinceptTerminal PRIVATE PkgConfig::LIBSECRET)
+            target_compile_definitions(FinceptTerminal PRIVATE FINCEPT_HAVE_LIBSECRET)
+            message(STATUS "libsecret found — Linux SecureStorage will use Secret Service backend")
+        else()
+            message(WARNING
+                "libsecret-1 not found — Linux credential storage falls back to "
+                "XOR-obfuscated QSettings (NOT cryptographically secure). "
+                "Install libsecret-1-dev and rebuild for production deployments.")
+        endif()
+    endif()
 endif()
 
 # Copy OpenSSL DLLs to build output — Windows only

--- a/fincept-qt/src/python/PythonRunner.cpp
+++ b/fincept-qt/src/python/PythonRunner.cpp
@@ -52,6 +52,33 @@ QString PythonRunner::scripts_dir() const {
     return scripts_dir_;
 }
 
+// ── Sensitive environment variable stripping ─────────────────────────────────
+// Removes credential-like variables inherited from the parent process before
+// passing the environment to a Python subprocess. This prevents API keys,
+// tokens, and passwords set in the user's shell from leaking into child
+// processes (readable via /proc/<pid>/environ on Linux or process inspection
+// tools on other platforms).
+//
+// Scripts that need a specific API key receive it via an explicit env.insert()
+// call at the call-site — never via implicit inheritance from the shell.
+static void strip_sensitive_env_vars(QProcessEnvironment& env) {
+    const QStringList all_keys = env.keys();
+    for (const QString& k : all_keys) {
+        const QString upper = k.toUpper();
+        if (upper.endsWith(QLatin1String("_API_KEY"))    ||
+            upper.endsWith(QLatin1String("_SECRET"))     ||
+            upper.endsWith(QLatin1String("_SECRET_KEY")) ||
+            upper.endsWith(QLatin1String("_ACCESS_TOKEN"))||
+            upper.endsWith(QLatin1String("_AUTH_TOKEN")) ||
+            upper.endsWith(QLatin1String("_TOKEN"))      ||
+            upper.endsWith(QLatin1String("_PASSWORD"))   ||
+            upper.endsWith(QLatin1String("_PRIVATE_KEY")))
+        {
+            env.remove(k);
+        }
+    }
+}
+
 // ── Standard Python environment ──────────────────────────────────────────────
 // Shared by PythonRunner::run() and external direct-QProcess callers
 // (e.g., AgentService's stdin/stream paths). Anything every Python spawn needs
@@ -59,6 +86,7 @@ QString PythonRunner::scripts_dir() const {
 // here. Script-specific path additions (parent-of-pkg) stay in run().
 QProcessEnvironment PythonRunner::build_python_env() const {
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    strip_sensitive_env_vars(env); // Never let shell-inherited credentials reach subprocesses
     env.insert("PYTHONIOENCODING", "utf-8");
     env.insert("PYTHONDONTWRITEBYTECODE", "1");
     env.insert("PYTHONUNBUFFERED", "1");

--- a/fincept-qt/src/storage/secure/SecureStorage.cpp
+++ b/fincept-qt/src/storage/secure/SecureStorage.cpp
@@ -2,19 +2,14 @@
 
 #include "core/logging/Logger.h"
 
-#include <QCryptographicHash>
-#include <QSettings>
-#include <QSysInfo>
-
 // ── Platform-specific credential storage ──────────────────────────────────────
 //
 // Windows : Windows Credential Manager (DPAPI-backed, encrypted at rest)
-// macOS   : Security.framework Keychain (encrypted, user-unlocked)
-// Linux   : XOR-obfuscated QSettings with machine-unique key derivation.
-//           NOTE: This is NOT cryptographically secure — it prevents casual
-//           inspection but not a determined attacker with filesystem access.
-//           For full security, use libsecret/Secret Service when available.
-//           A proper libsecret backend should be added in a future release.
+// macOS   : Security.framework SecItem API (SecItemAdd/Update/CopyMatching)
+// Linux   : libsecret / Secret Service when available (GNOME Keyring, KWallet),
+//           falling back to XOR-obfuscated QSettings when libsecret is absent.
+//           The XOR fallback is NOT cryptographically secure — it only prevents
+//           casual inspection. Build with libsecret-1-dev for production use.
 
 #ifdef Q_OS_WIN
 #    include <windows.h>
@@ -24,7 +19,17 @@
 #endif
 
 #ifdef Q_OS_MAC
+#    include <CoreFoundation/CoreFoundation.h>
 #    include <Security/Security.h>
+#endif
+
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
+#    include <QCryptographicHash>
+#    include <QSettings>
+#    include <QSysInfo>
+#    ifdef FINCEPT_HAVE_LIBSECRET
+#        include <libsecret/secret.h>
+#    endif
 #endif
 
 static constexpr auto TAG = "SecureStorage";
@@ -35,30 +40,46 @@ namespace fincept {
 SecureStorage& SecureStorage::instance() {
     static SecureStorage s;
 
-#if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
-    // One-time honest warning on Linux: the backend here is XOR-obfuscated
-    // QSettings, not real encryption. Emit at first access so it always
-    // shows up in the startup log for operators, and only once per process.
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MAC) && !defined(FINCEPT_HAVE_LIBSECRET)
+    // Warn once at startup when running on Linux without libsecret. Operators
+    // should install libsecret-1-dev and rebuild for production deployments.
     static bool warned_once = false;
     if (!warned_once) {
         warned_once = true;
-        LOG_WARN("SecureStorage",
-                 "Linux backend is XOR-obfuscated QSettings — NOT cryptographically "
-                 "secure. Anyone with read access to the user profile can recover "
-                 "stored secrets. libsecret/KWallet backend is planned.");
+        LOG_WARN(TAG,
+                 "Linux credential storage is using XOR-obfuscated QSettings — "
+                 "NOT cryptographically secure. Install libsecret-1-dev and rebuild "
+                 "to enable the Secret Service (GNOME Keyring / KWallet) backend.");
     }
 #endif
 
     return s;
 }
 
-// ── Linux helpers ─────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// Linux helpers
+// ─────────────────────────────────────────────────────────────────────────────
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
 
-// Derive a machine-unique obfuscation key from stable system identifiers.
-// Not a secret — just prevents the file being readable at a glance.
+#ifdef FINCEPT_HAVE_LIBSECRET
+
+static const SecretSchema* fincept_schema() {
+    static const SecretSchema schema = {
+        "com.fincept.terminal",
+        SECRET_SCHEMA_NONE,
+        {
+            { "fincept-key", SECRET_SCHEMA_ATTRIBUTE_STRING },
+            { nullptr, SecretSchemaAttributeType(0) }
+        }
+    };
+    return &schema;
+}
+
+#else // XOR fallback helpers
+
 static QByteArray machine_key() {
-    const QString seed = QSysInfo::machineUniqueId() + QSysInfo::productType() + QLatin1String(kService);
+    const QString seed = QSysInfo::machineUniqueId() + QSysInfo::productType()
+                         + QLatin1String(kService);
     return QCryptographicHash::hash(seed.toUtf8(), QCryptographicHash::Sha256);
 }
 
@@ -67,14 +88,18 @@ static QByteArray xor_obfuscate(const QByteArray& data) {
     QByteArray out;
     out.resize(data.size());
     for (int i = 0; i < data.size(); ++i)
-        out[i] =
-            static_cast<char>(static_cast<unsigned char>(data[i]) ^ static_cast<unsigned char>(key[i % key.size()]));
+        out[i] = static_cast<char>(
+            static_cast<unsigned char>(data[i]) ^
+            static_cast<unsigned char>(key[i % key.size()]));
     return out;
 }
 
+#endif // FINCEPT_HAVE_LIBSECRET
 #endif // Linux helpers
 
-// ── store ─────────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// store
+// ─────────────────────────────────────────────────────────────────────────────
 
 Result<void> SecureStorage::store(const QString& key, const QString& value) {
 #ifdef Q_OS_WIN
@@ -96,50 +121,96 @@ Result<void> SecureStorage::store(const QString& key, const QString& value) {
     return Result<void>::ok();
 
 #elif defined(Q_OS_MAC)
-    // macOS Keychain — encrypted, user-unlocked.
-    // NOTE: Using legacy SecKeychain* API (deprecated in 10.10). The modern
-    // SecItem* API is a larger port; suppressing the warning locally keeps
-    // CI green. TODO: migrate to SecItemAdd / SecItemCopyMatching.
-    const QByteArray svc = QByteArray(kService);
-    const QByteArray acct = key.toUtf8();
-    const QByteArray data = value.toUtf8();
+    // macOS Keychain via modern SecItem API (no deprecated SecKeychain* calls)
+    const QByteArray svc_bytes = QByteArray(kService);
+    const QByteArray acct_bytes = key.toUtf8();
+    const QByteArray data_bytes = value.toUtf8();
 
-    OSStatus status;
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    // Delete any existing item first (SecItemUpdate is more complex)
-    SecKeychainItemRef existing = nullptr;
-    OSStatus del_status =
-        SecKeychainFindGenericPassword(nullptr, static_cast<UInt32>(svc.size()), svc.constData(),
-                                       static_cast<UInt32>(acct.size()), acct.constData(), nullptr, nullptr, &existing);
-    if (del_status == errSecSuccess && existing) {
-        SecKeychainItemDelete(existing);
-        CFRelease(existing);
+    CFStringRef service = CFStringCreateWithBytes(
+        nullptr, reinterpret_cast<const UInt8*>(svc_bytes.constData()),
+        svc_bytes.size(), kCFStringEncodingUTF8, false);
+    CFStringRef account = CFStringCreateWithBytes(
+        nullptr, reinterpret_cast<const UInt8*>(acct_bytes.constData()),
+        acct_bytes.size(), kCFStringEncodingUTF8, false);
+    CFDataRef secret_data = CFDataCreate(
+        nullptr, reinterpret_cast<const UInt8*>(data_bytes.constData()),
+        static_cast<CFIndex>(data_bytes.size()));
+
+    // Try to update an existing item first
+    const void* find_keys[] = { kSecClass, kSecAttrService, kSecAttrAccount };
+    const void* find_vals[] = { kSecClassGenericPassword, service, account };
+    CFDictionaryRef find_query = CFDictionaryCreate(nullptr, find_keys, find_vals, 3,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    const void* upd_keys[] = { kSecValueData };
+    const void* upd_vals[] = { secret_data };
+    CFDictionaryRef upd_attrs = CFDictionaryCreate(nullptr, upd_keys, upd_vals, 1,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    OSStatus status = SecItemUpdate(find_query, upd_attrs);
+    CFRelease(upd_attrs);
+
+    if (status == errSecItemNotFound) {
+        // No existing item — add a new one
+        const void* add_keys[] = { kSecClass, kSecAttrService, kSecAttrAccount, kSecValueData };
+        const void* add_vals[] = { kSecClassGenericPassword, service, account, secret_data };
+        CFDictionaryRef add_attrs = CFDictionaryCreate(nullptr, add_keys, add_vals, 4,
+            &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+        status = SecItemAdd(add_attrs, nullptr);
+        CFRelease(add_attrs);
     }
 
-    status = SecKeychainAddGenericPassword(nullptr, static_cast<UInt32>(svc.size()), svc.constData(),
-                                           static_cast<UInt32>(acct.size()), acct.constData(),
-                                           static_cast<UInt32>(data.size()), data.constData(), nullptr);
-#    pragma clang diagnostic pop
+    CFRelease(find_query);
+    CFRelease(secret_data);
+    CFRelease(account);
+    CFRelease(service);
 
     if (status != errSecSuccess) {
-        LOG_ERROR(TAG, QString("Keychain store failed (OSStatus %1) for key: %2").arg(status).arg(key));
+        LOG_ERROR(TAG, QString("Keychain store failed (OSStatus %1) for key: %2")
+                           .arg(status).arg(key));
         return Result<void>::err("Failed to store in Keychain");
     }
     return Result<void>::ok();
 
 #else
-    // Linux — XOR-obfuscated QSettings.
-    // WARNING: Not cryptographically secure. Prevents casual inspection only.
-    // TODO: Add libsecret backend for proper encryption on Linux.
+#    ifdef FINCEPT_HAVE_LIBSECRET
+    // Linux — Secret Service (GNOME Keyring / KWallet compatibility layer)
+    GError* err = nullptr;
+    const QByteArray key_bytes = key.toUtf8();
+    const QByteArray val_bytes = value.toUtf8();
+    const QByteArray label = ("Fincept Terminal: " + key).toUtf8();
+
+    secret_password_store_sync(
+        fincept_schema(),
+        SECRET_COLLECTION_DEFAULT,
+        label.constData(),
+        val_bytes.constData(),
+        nullptr,
+        &err,
+        "fincept-key", key_bytes.constData(),
+        nullptr);
+
+    if (err) {
+        QString msg = QString::fromUtf8(err->message);
+        g_error_free(err);
+        LOG_ERROR(TAG, "libsecret store failed for key " + key + ": " + msg);
+        return Result<void>::err("Failed to store in Secret Service: " + msg.toStdString());
+    }
+    return Result<void>::ok();
+
+#    else
+    // XOR-obfuscated QSettings fallback — not cryptographically secure.
     QSettings s("Fincept", "FinceptTerminal-Secure");
     const QByteArray obfuscated = xor_obfuscate(value.toUtf8()).toBase64();
     s.setValue("secure/" + key, QString::fromLatin1(obfuscated));
     return Result<void>::ok();
+#    endif
 #endif
 }
 
-// ── retrieve ──────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// retrieve
+// ─────────────────────────────────────────────────────────────────────────────
 
 Result<QString> SecureStorage::retrieve(const QString& key) {
 #ifdef Q_OS_WIN
@@ -150,51 +221,89 @@ Result<QString> SecureStorage::retrieve(const QString& key) {
         return Result<QString>::err("Credential not found");
     }
 
-    QString value = QString::fromUtf8(reinterpret_cast<const char*>(cred->CredentialBlob),
-                                      static_cast<int>(cred->CredentialBlobSize));
+    QString value = QString::fromUtf8(
+        reinterpret_cast<const char*>(cred->CredentialBlob),
+        static_cast<int>(cred->CredentialBlobSize));
     CredFree(cred);
     return Result<QString>::ok(value);
 
 #elif defined(Q_OS_MAC)
-    const QByteArray svc = QByteArray(kService);
-    const QByteArray acct = key.toUtf8();
+    const QByteArray svc_bytes = QByteArray(kService);
+    const QByteArray acct_bytes = key.toUtf8();
 
-    UInt32 data_len = 0;
-    void* data_ptr = nullptr;
-    OSStatus status;
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    status = SecKeychainFindGenericPassword(nullptr, static_cast<UInt32>(svc.size()), svc.constData(),
-                                            static_cast<UInt32>(acct.size()), acct.constData(), &data_len,
-                                            &data_ptr, nullptr);
-#    pragma clang diagnostic pop
+    CFStringRef service = CFStringCreateWithBytes(
+        nullptr, reinterpret_cast<const UInt8*>(svc_bytes.constData()),
+        svc_bytes.size(), kCFStringEncodingUTF8, false);
+    CFStringRef account = CFStringCreateWithBytes(
+        nullptr, reinterpret_cast<const UInt8*>(acct_bytes.constData()),
+        acct_bytes.size(), kCFStringEncodingUTF8, false);
 
-    if (status != errSecSuccess) {
+    const void* keys[] = { kSecClass, kSecAttrService, kSecAttrAccount,
+                           kSecReturnData, kSecMatchLimit };
+    const void* vals[] = { kSecClassGenericPassword, service, account,
+                           kCFBooleanTrue, kSecMatchLimitOne };
+    CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, vals, 5,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    CFTypeRef result_ref = nullptr;
+    OSStatus status = SecItemCopyMatching(query, &result_ref);
+    CFRelease(query);
+    CFRelease(account);
+    CFRelease(service);
+
+    if (status != errSecSuccess || !result_ref) {
         return Result<QString>::err("Credential not found in Keychain");
     }
 
-    QString value = QString::fromUtf8(static_cast<const char*>(data_ptr), static_cast<int>(data_len));
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    SecKeychainItemFreeContent(nullptr, data_ptr);
-#    pragma clang diagnostic pop
+    CFDataRef data = static_cast<CFDataRef>(result_ref);
+    QString value = QString::fromUtf8(
+        reinterpret_cast<const char*>(CFDataGetBytePtr(data)),
+        static_cast<int>(CFDataGetLength(data)));
+    CFRelease(result_ref);
     return Result<QString>::ok(value);
 
 #else
+#    ifdef FINCEPT_HAVE_LIBSECRET
+    GError* err = nullptr;
+    const QByteArray key_bytes = key.toUtf8();
+
+    gchar* password = secret_password_lookup_sync(
+        fincept_schema(),
+        nullptr,
+        &err,
+        "fincept-key", key_bytes.constData(),
+        nullptr);
+
+    if (err) {
+        QString msg = QString::fromUtf8(err->message);
+        g_error_free(err);
+        return Result<QString>::err("libsecret lookup failed: " + msg.toStdString());
+    }
+    if (!password) {
+        return Result<QString>::err("Not found");
+    }
+
+    QString value = QString::fromUtf8(password);
+    secret_password_free(password);
+    return Result<QString>::ok(value);
+
+#    else
     QSettings s("Fincept", "FinceptTerminal-Secure");
     QVariant v = s.value("secure/" + key);
     if (!v.isValid())
         return Result<QString>::err("Not found");
 
-    // Deobfuscate: base64-decode then XOR
     const QByteArray raw = QByteArray::fromBase64(v.toString().toLatin1());
     if (raw.isEmpty())
         return Result<QString>::err("Not found");
     return Result<QString>::ok(QString::fromUtf8(xor_obfuscate(raw)));
+#    endif
 #endif
 }
 
-// ── remove ────────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// remove
+// ─────────────────────────────────────────────────────────────────────────────
 
 Result<void> SecureStorage::remove(const QString& key) {
 #ifdef Q_OS_WIN
@@ -205,27 +314,48 @@ Result<void> SecureStorage::remove(const QString& key) {
     return Result<void>::ok();
 
 #elif defined(Q_OS_MAC)
-    const QByteArray svc = QByteArray(kService);
-    const QByteArray acct = key.toUtf8();
+    const QByteArray svc_bytes = QByteArray(kService);
+    const QByteArray acct_bytes = key.toUtf8();
 
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    SecKeychainItemRef item = nullptr;
-    OSStatus status =
-        SecKeychainFindGenericPassword(nullptr, static_cast<UInt32>(svc.size()), svc.constData(),
-                                       static_cast<UInt32>(acct.size()), acct.constData(), nullptr, nullptr, &item);
+    CFStringRef service = CFStringCreateWithBytes(
+        nullptr, reinterpret_cast<const UInt8*>(svc_bytes.constData()),
+        svc_bytes.size(), kCFStringEncodingUTF8, false);
+    CFStringRef account = CFStringCreateWithBytes(
+        nullptr, reinterpret_cast<const UInt8*>(acct_bytes.constData()),
+        acct_bytes.size(), kCFStringEncodingUTF8, false);
 
-    if (status == errSecSuccess && item) {
-        SecKeychainItemDelete(item);
-        CFRelease(item);
-    }
-#    pragma clang diagnostic pop
+    const void* keys[] = { kSecClass, kSecAttrService, kSecAttrAccount };
+    const void* vals[] = { kSecClassGenericPassword, service, account };
+    CFDictionaryRef query = CFDictionaryCreate(nullptr, keys, vals, 3,
+        &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    SecItemDelete(query);
+    CFRelease(query);
+    CFRelease(account);
+    CFRelease(service);
     return Result<void>::ok();
 
 #else
+#    ifdef FINCEPT_HAVE_LIBSECRET
+    GError* err = nullptr;
+    const QByteArray key_bytes = key.toUtf8();
+
+    secret_password_clear_sync(
+        fincept_schema(),
+        nullptr,
+        &err,
+        "fincept-key", key_bytes.constData(),
+        nullptr);
+
+    if (err)
+        g_error_free(err); // Not fatal — item may not have existed
+    return Result<void>::ok();
+
+#    else
     QSettings s("Fincept", "FinceptTerminal-Secure");
     s.remove("secure/" + key);
     return Result<void>::ok();
+#    endif
 #endif
 }
 


### PR DESCRIPTION
## Summary

- **Linux SecureStorage**: Implement libsecret / Secret Service backend (GNOME Keyring, KWallet) to replace the insecure XOR-obfuscated QSettings. Auto-detected at build time via `pkg-config libsecret-1`. XOR fallback is retained for systems without libsecret, with a clear startup warning.
- **macOS SecureStorage**: Migrate fully from the deprecated `SecKeychain*` API (deprecated since macOS 10.10) to the modern `SecItem` API (`SecItemAdd` / `SecItemUpdate` / `SecItemCopyMatching` / `SecItemDelete`). All `#pragma clang diagnostic ignored` suppressions removed.
- **PythonRunner env isolation**: Add `strip_sensitive_env_vars()` which strips environment variables with suffixes `_API_KEY`, `_SECRET`, `_SECRET_KEY`, `_ACCESS_TOKEN`, `_AUTH_TOKEN`, `_TOKEN`, `_PASSWORD`, and `_PRIVATE_KEY` before spawning any Python subprocess. Prevents shell-inherited credentials from leaking via `/proc/<pid>/environ` or platform process inspection tools.

## Files changed

- `fincept-qt/src/storage/secure/SecureStorage.cpp`
- `fincept-qt/src/python/PythonRunner.cpp`
- `fincept-qt/CMakeLists.txt`

## Test plan

- [x] Build on Windows — Credential Manager path unchanged, smoke test store/retrieve
- [x] Build on macOS — SecItem path works, no deprecation warnings in compiler output
- [x] Build on Linux **with** `libsecret-1-dev` — CMake log shows `libsecret found`, store/retrieve via Secret Service
- [x] Build on Linux **without** `libsecret-1-dev` — CMake warning shown, XOR fallback works, startup log warns
- [x] Set an API key in the app, restart, confirm key persists correctly on all platforms
- [x] Verify Python subprocesses no longer inherit `OPENAI_API_KEY` or `FRED_API_KEY` from the shell environment

