### PR TITLE
fix(windows): pin embedded Python to 3.11.9 and remove runtime 3.12 hard-codes

### DIFF
--- a/fincept-qt/src/python/PythonSetupManager.cpp
+++ b/fincept-qt/src/python/PythonSetupManager.cpp
@@ -78,17 +78,24 @@ QString PythonSetupManager::base_python_path() const {
         return cached_python_path_;
     }
 
-    // Fallback: scan known install directory for the cpython-3.12 subdirectory.
+    // Fallback: scan known install directory for cpython folders.
+    // Prefer exact patch pin (e.g. cpython-3.11.9*) and then major.minor.
+    const QString python_version = QString::fromLatin1(kPythonVersion);
+    const QString python_series = python_version.section('.', 0, 1);
+    QStringList patterns{QString("cpython-%1*").arg(python_version)};
+    if (!python_series.isEmpty() && python_series != python_version) {
+        patterns << QString("cpython-%1*").arg(python_series);
+    }
 #ifdef _WIN32
     QDir py_dir(install_dir() + "/python");
-    auto entries = py_dir.entryList({"cpython-3.12*"}, QDir::Dirs);
+    auto entries = py_dir.entryList(patterns, QDir::Dirs);
     if (!entries.isEmpty()) {
         cached_python_path_ = py_dir.filePath(entries.first() + "/python.exe");
         return cached_python_path_;
     }
 #else
     QDir py_dir(install_dir() + "/python");
-    auto entries = py_dir.entryList({"cpython-3.12*"}, QDir::Dirs);
+    auto entries = py_dir.entryList(patterns, QDir::Dirs);
     if (!entries.isEmpty()) {
         cached_python_path_ = py_dir.filePath(entries.first() + "/bin/python3");
         return cached_python_path_;
@@ -507,13 +514,15 @@ void PythonSetupManager::run_setup() {
 
         // ── Step 2: Install Python via UV ────────────────────────────────────
         if (!status.python_installed) {
-            self->emit_progress("python", 0, "Installing Python 3.12 via UV...");
+            self->emit_progress("python", 0,
+                                QString("Installing Python %1 via UV...").arg(QString::fromLatin1(kPythonVersion)));
             if (!self->install_python_via_uv()) {
                 self->emit_progress("python", 0, "Failed to install Python", true);
                 fail("Python installation failed");
                 return;
             }
-            self->emit_progress("python", 100, "Python 3.12 installed");
+            self->emit_progress("python", 100,
+                                QString("Python %1 installed").arg(QString::fromLatin1(kPythonVersion)));
         } else {
             self->emit_progress("python", 100, "Python already installed: " + status.python_version);
         }
@@ -732,7 +741,8 @@ bool PythonSetupManager::download_uv() {
 // ─────────────────────────────────────────────────────────────────────────────
 
 bool PythonSetupManager::install_python_via_uv() {
-    emit_progress("python", 20, "UV is downloading Python 3.12...");
+    emit_progress("python", 20,
+                  QString("UV is downloading Python %1...").arg(QString::fromLatin1(kPythonVersion)));
 
     // Shared UV env (cache dir, hardlinks, bytecode compile, concurrency, timeout).
     QStringList env = uv_env_extra();

--- a/fincept-qt/src/python/PythonSetupManager.h
+++ b/fincept-qt/src/python/PythonSetupManager.h
@@ -4,7 +4,7 @@
 //
 // Flow:
 //   1. Download UV standalone binary (~13MB) — single download, no pip/get-pip.py
-//   2. uv python install 3.12                — UV handles Python download internally
+//   2. uv python install 3.11.9              — UV handles Python download internally
 //   3. uv venv venv-numpy1 + venv-numpy2     — PARALLEL venv creation
 //   4. uv pip install requirements            — PARALLEL package install (UV is 10-100x faster than pip)
 //
@@ -111,7 +111,7 @@ class PythonSetupManager : public QObject {
     bool verify_packages_installed(const QString& venv_name,
                                    const QString& requirements_file) const;
 
-    static constexpr const char* kPythonVersion = "3.12";
+    static constexpr const char* kPythonVersion = "3.11.9";
     static constexpr const char* kUvVersion = "0.7.12";
 
     // Session-lifetime caches — requirements files never change at runtime.

--- a/fincept-qt/src/screens/code_editor/CodeEditorScreen.cpp
+++ b/fincept-qt/src/screens/code_editor/CodeEditorScreen.cpp
@@ -952,7 +952,7 @@ QWidget* CodeEditorScreen::build_toolbar() {
                                      .arg(colors::POSITIVE(), fonts::DATA_FAMILY));
     hl->addWidget(kernel_label_);
 
-    auto* py_label = new QLabel("Python 3.12", bar);
+    auto* py_label = new QLabel("Python 3.11.9", bar);
     py_label->setStyleSheet(QString("color:%1; font-family:%2; font-size:10px; padding-left:8px;")
                                 .arg(colors::TEXT_TERTIARY(), fonts::DATA_FAMILY));
     hl->addWidget(py_label);

--- a/fincept-qt/src/screens/info/HelpScreen.cpp
+++ b/fincept-qt/src/screens/info/HelpScreen.cpp
@@ -279,7 +279,7 @@ HelpScreen::HelpScreen(QWidget* parent) : QWidget(parent) {
 
             {"💻", "What are the system requirements?",
              "Windows 10+ (x64), macOS 12+, or Linux (glibc 2.31+). 8 GB RAM recommended. "
-             "Active internet required for data feeds. Python 3.12 is installed automatically "
+             "Active internet required for data feeds. Python 3.11.9 is installed automatically "
              "during first-time setup."},
 
             {"🔒", "Is my data secure?",


### PR DESCRIPTION
## Summary
This fixes a Windows startup regression where fresh installs could resolve and install Python 3.12.x (via `uv python install 3.12`) even though the project/toolchain is pinned to Python 3.11.9.

## Root Cause
- `PythonSetupManager` used:
  - `kPythonVersion = "3.12"` (unpinned major.minor)
  - fallback discovery glob `cpython-3.12*`
- That made installs non-reproducible and mismatched with documented/runtime expectations.

## Changes
- Pin embedded Python to `3.11.9` in `PythonSetupManager`.
- Make fallback interpreter discovery derive from `kPythonVersion`:
  - prefer `cpython-<exact-version>*`
  - fallback to `cpython-<major.minor>*`
- Replace hard-coded setup messages (`Python 3.12`) with dynamic messages from `kPythonVersion`.
- Align UI/help copy to `Python 3.11.9`.

## Files changed
- `fincept-qt/src/python/PythonSetupManager.h`
- `fincept-qt/src/python/PythonSetupManager.cpp`
- `fincept-qt/src/screens/code_editor/CodeEditorScreen.cpp`
- `fincept-qt/src/screens/info/HelpScreen.cpp`

## Validation
- Verified no remaining runtime `3.12` hard-codes in setup/path resolution under `src/python`.
- Confirmed diff scope is limited to the four files above.

## Notes
- This addresses Python version mismatch/non-determinism on fresh installs.
- Windows crash reproduction/verification should be confirmed on a clean Windows 11 26H2 machine after packaging.
