### PR TITLE
macos build fix: ifdef-guard Win32 debug block in TerminalShell

### DIFF
--- a/fincept-qt/src/app/TerminalShell.cpp
+++ b/fincept-qt/src/app/TerminalShell.cpp
@@ -135,6 +135,7 @@ void TerminalShell::initialise() {
     FT_TS(115);
     QString _ws_path = ProfilePaths::workspace_db();
     FT_TS(1150);
+#ifdef Q_OS_WIN
     char _path_msg[512];
     _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
     OutputDebugStringA(_path_msg);
@@ -142,6 +143,7 @@ void TerminalShell::initialise() {
         HANDLE _h = CreateFileA("C:\\Users\\Tilak\\AppData\\Local\\Temp\\ft_marks.txt", FILE_APPEND_DATA, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (_h != INVALID_HANDLE_VALUE) { DWORD _w; SetFilePointer(_h, 0, NULL, FILE_END); WriteFile(_h, _path_msg, (DWORD)strlen(_path_msg), &_w, NULL); CloseHandle(_h); }
     }
+#endif
     auto db_open = workspace_db_->open(_ws_path);
     FT_TS(116);
     if (db_open.is_err()) {


### PR DESCRIPTION
The inline OutputDebugStringA/CreateFileA block in TerminalShell::initialise() was missing a Q_OS_WIN guard, causing 13 compile errors on macOS/clang. Wrapped it in #ifdef Q_OS_WIN to match the FT_TS macro at the top of the file.