### PR TITLE
Fix macOS/Linux build: remove Windows-only debug code from TerminalShell

### DIFF
--- a/fincept-qt/src/app/TerminalShell.cpp
+++ b/fincept-qt/src/app/TerminalShell.cpp
@@ -135,13 +135,6 @@ void TerminalShell::initialise() {
     FT_TS(115);
     QString _ws_path = ProfilePaths::workspace_db();
     FT_TS(1150);
-    char _path_msg[512];
-    _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
-    OutputDebugStringA(_path_msg);
-    {
-        HANDLE _h = CreateFileA("C:\\Users\\Tilak\\AppData\\Local\\Temp\\ft_marks.txt", FILE_APPEND_DATA, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-        if (_h != INVALID_HANDLE_VALUE) { DWORD _w; SetFilePointer(_h, 0, NULL, FILE_END); WriteFile(_h, _path_msg, (DWORD)strlen(_path_msg), &_w, NULL); CloseHandle(_h); }
-    }
     auto db_open = workspace_db_->open(_ws_path);
     FT_TS(116);
     if (db_open.is_err()) {


### PR DESCRIPTION
## What changed

Removed 7 lines of unguarded Windows-only debug code from `TerminalShell::initialise()` in `fincept-qt/src/app/TerminalShell.cpp`.

## Why

The removed code used Windows-only APIs (`_snprintf_s`/`_TRUNCATE`, `OutputDebugStringA`, `CreateFileA`, `HANDLE`, `DWORD`) with no `#ifdef _WIN32` guard, causing **13 compile errors** on every macOS and Linux build:

```
error: use of undeclared identifier '_TRUNCATE'
error: use of undeclared identifier 'OutputDebugStringA'
error: unknown type name 'HANDLE'
error: use of undeclared identifier 'FILE_APPEND_DATA'
...
```

The code also wrote to a hardcoded developer path (`C:\Users\Tilak\AppData\Local\Temp\ft_marks.txt`), confirming it was temporary debug instrumentation accidentally committed without platform guards.

## Impact

- **macOS/Linux**: app now builds and runs correctly (was completely broken)
- **Windows**: no change — the removed code was debug-only output, not production logic

## Testing

Clean build confirmed via `ninja -C build/macos-release`. App launches successfully on macOS.