### PR TITLE
fix(auth): add backend failover for signup/login/health to mitigate 502 outages

### DIFF
--- a/fincept-qt/src/auth/AuthApi.cpp
+++ b/fincept-qt/src/auth/AuthApi.cpp
@@ -1,9 +1,12 @@
 #include "auth/AuthApi.h"
 
+#include "core/config/AppConfig.h"
 #include "core/logging/Logger.h"
 #include "network/http/HttpClient.h"
 
 #include <QJsonDocument>
+
+#include <memory>
 
 namespace fincept::auth {
 
@@ -65,6 +68,22 @@ static QString parse_422_detail(const QJsonDocument& doc) {
 
 void AuthApi::request(const QString& method, const QString& endpoint, const QJsonObject& body, Callback cb) {
     auto& http = fincept::HttpClient::instance();
+    auto& config = fincept::AppConfig::instance();
+
+    auto make_url = [&endpoint](const QString& base) {
+        QString normalized = base.trimmed();
+        if (normalized.endsWith('/'))
+            normalized.chop(1);
+        return normalized + endpoint;
+    };
+
+    auto hosts = config.auth_base_urls();
+    const QString primary = config.api_base_url().trimmed();
+    if (!primary.isEmpty() && !hosts.contains(primary))
+        hosts.prepend(primary);
+    hosts.removeAll(QString{});
+    if (hosts.isEmpty())
+        hosts = {"https://api.fincept.in"};
 
     auto handle = [cb, endpoint](fincept::Result<QJsonDocument> result) {
         // ── No body / network error path ─────────────────────────────────────
@@ -162,14 +181,45 @@ void AuthApi::request(const QString& method, const QString& endpoint, const QJso
         cb({true, obj, {}, 200});
     };
 
-    if (method == "GET")
-        http.get(endpoint, handle);
-    else if (method == "POST")
-        http.post(endpoint, body, handle);
-    else if (method == "PUT")
-        http.put(endpoint, body, handle);
-    else if (method == "DELETE")
-        http.del(endpoint, handle);
+    auto should_retry = [](const fincept::Result<QJsonDocument>& result) {
+        if (!result.is_err())
+            return false;
+        QString err = QString::fromStdString(result.error());
+        int status = 0;
+        if (err.startsWith("HTTP_"))
+            status = err.mid(5).toInt();
+        return status == 0 || status == 502 || status == 503 || status == 504;
+    };
+
+    using RawResultCallback = std::function<void(fincept::Result<QJsonDocument>)>;
+    auto request_on_host = [&http, &method, &body](const QString& url, RawResultCallback done) {
+        if (method == "GET")
+            http.get(url, [done](fincept::Result<QJsonDocument> r) { done(std::move(r)); });
+        else if (method == "POST")
+            http.post(url, body, [done](fincept::Result<QJsonDocument> r) { done(std::move(r)); });
+        else if (method == "PUT")
+            http.put(url, body, [done](fincept::Result<QJsonDocument> r) { done(std::move(r)); });
+        else if (method == "DELETE")
+            http.del(url, [done](fincept::Result<QJsonDocument> r) { done(std::move(r)); });
+    };
+
+    auto idx = std::make_shared<int>(0);
+    auto attempt = std::make_shared<std::function<void()>>();
+    *attempt = [hosts, idx, handle, should_retry, request_on_host, make_url, endpoint, attempt]() {
+        const QString url = make_url(hosts.at(*idx));
+        request_on_host(url, [hosts, idx, handle, should_retry, endpoint, attempt](fincept::Result<QJsonDocument> r) {
+            if (should_retry(r) && (*idx + 1) < hosts.size()) {
+                const QString failed = hosts.at(*idx);
+                ++(*idx);
+                const QString next = hosts.at(*idx);
+                LOG_WARN("Auth", QString("Retrying %1 on fallback backend: %2 -> %3").arg(endpoint, failed, next));
+                (*attempt)();
+                return;
+            }
+            handle(std::move(r));
+        });
+    };
+    (*attempt)();
 }
 
 // ── Health ───────────────────────────────────────────────────────────────────

--- a/fincept-qt/src/core/config/AppConfig.cpp
+++ b/fincept-qt/src/core/config/AppConfig.cpp
@@ -25,6 +25,18 @@ QString AppConfig::api_base_url() const {
     return settings_.value("api/base_url", "https://api.fincept.in").toString();
 }
 
+QStringList AppConfig::auth_base_urls() const {
+    QStringList urls = settings_.value("auth/base_urls").toStringList();
+    if (urls.isEmpty()) {
+        urls = {
+            "https://api.fincept.in",
+            "https://finceptbackend.share.zrok.io",
+        };
+    }
+    urls.removeDuplicates();
+    return urls;
+}
+
 bool AppConfig::dark_mode() const {
     return settings_.value("ui/dark_mode", true).toBool();
 }

--- a/fincept-qt/src/core/config/AppConfig.h
+++ b/fincept-qt/src/core/config/AppConfig.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <QSettings>
 #include <QString>
+#include <QStringList>
 #include <QVariant>
 
 namespace fincept {
@@ -16,6 +17,7 @@ class AppConfig {
 
     // Typed accessors for common settings
     QString api_base_url() const;
+    QStringList auth_base_urls() const;
     bool dark_mode() const;
     int refresh_interval_ms() const;
 


### PR DESCRIPTION
## What happened
Fincept Terminal auth flows (signup/login/guest/health) were brittle because they depended on a single backend host (`https://api.fincept.in`), and users reported consistent HTTP 502 failures.

## What this PR changes
- Adds configurable auth backend list via `AppConfig::auth_base_urls()`.
- Introduces default auth backend fallback chain:
  1. `https://api.fincept.in`
  2. `https://finceptbackend.share.zrok.io`
- Updates `AuthApi::request(...)` to retry auth requests on fallback backend when primary fails with:
  - `HTTP 502`
  - `HTTP 503`
  - `HTTP 504`
  - network-level failure (`status == 0`)

## Scope
This is intentionally scoped to auth API calls handled by `AuthApi` (signup/login/health/etc.) to avoid broad behavioral changes in unrelated services.

## Why
This makes account creation and authentication flows resilient to temporary gateway outages or host migration mismatches without requiring immediate client reconfiguration.

## Files changed
- `fincept-qt/src/core/config/AppConfig.h`
- `fincept-qt/src/core/config/AppConfig.cpp`
- `fincept-qt/src/auth/AuthApi.cpp`


Closes #215
