### PR TITLE
Fix macOS TerminalShell debug output build

### DIFF
--- a/fincept-qt/src/app/TerminalShell.cpp
+++ b/fincept-qt/src/app/TerminalShell.cpp
@@ -135,13 +135,19 @@ void TerminalShell::initialise() {
     FT_TS(115);
     QString _ws_path = ProfilePaths::workspace_db();
     FT_TS(1150);
+    const QByteArray _ws_path_utf8 = _ws_path.toUtf8();
+#ifdef Q_OS_WIN
     char _path_msg[512];
-    _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
+    _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path_utf8.constData());
     OutputDebugStringA(_path_msg);
     {
         HANDLE _h = CreateFileA("C:\\Users\\Tilak\\AppData\\Local\\Temp\\ft_marks.txt", FILE_APPEND_DATA, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (_h != INVALID_HANDLE_VALUE) { DWORD _w; SetFilePointer(_h, 0, NULL, FILE_END); WriteFile(_h, _path_msg, (DWORD)strlen(_path_msg), &_w, NULL); CloseHandle(_h); }
     }
+#else
+    fprintf(stderr, "FT_TS workspace_db path: %s\n", _ws_path_utf8.constData());
+    fflush(stderr);
+#endif
     auto db_open = workspace_db_->open(_ws_path);
     FT_TS(116);
     if (db_open.is_err()) {


### PR DESCRIPTION
Closes #254

## Summary
- Guard the Windows-only `TerminalShell` workspace path trace so macOS builds no longer compile raw Win32 symbols.
- Preserve the existing Windows debug trace behavior.
- Emit the same diagnostic line to `stderr` for non-Windows builds.

## Problem
The macOS setup flow can fail during compilation because `TerminalShell.cpp` logs the `workspace_db` path with `_snprintf_s`, `_TRUNCATE`, `OutputDebugStringA`, `HANDLE`, `CreateFileA`, and related Win32 constants outside the existing `Q_OS_WIN` guarded trace macro.

## Fix
The workspace DB path is still converted to UTF-8 once. The Windows `OutputDebugStringA` / `ft_marks.txt` trace stays under `Q_OS_WIN`, while other platforms use `fprintf(stderr, ...)` for the same trace line.

## Validation
- `cmake --build fincept-qt/build/macos-release`

The local macOS build completed successfully before the PR branches were split.