### PR TITLE
fix: guard Windows debug logging in TerminalShell behind platform #ifdef

### DIFF
--- a/fincept-qt/src/app/TerminalShell.cpp
+++ b/fincept-qt/src/app/TerminalShell.cpp
@@ -135,13 +135,23 @@ void TerminalShell::initialise() {
     FT_TS(115);
     QString _ws_path = ProfilePaths::workspace_db();
     FT_TS(1150);
-    char _path_msg[512];
-    _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
-    OutputDebugStringA(_path_msg);
+#if defined(_WIN32)
     {
+        char _path_msg[512];
+        _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
+        OutputDebugStringA(_path_msg);
         HANDLE _h = CreateFileA("C:\\Users\\Tilak\\AppData\\Local\\Temp\\ft_marks.txt", FILE_APPEND_DATA, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (_h != INVALID_HANDLE_VALUE) { DWORD _w; SetFilePointer(_h, 0, NULL, FILE_END); WriteFile(_h, _path_msg, (DWORD)strlen(_path_msg), &_w, NULL); CloseHandle(_h); }
     }
+#else
+    {
+        char _path_msg[512];
+        std::snprintf(_path_msg, sizeof(_path_msg), "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
+        const char* _log_path = "/tmp/ft_marks.txt";
+        if (FILE* _f = std::fopen(_log_path, "a")) { std::fputs(_path_msg, _f); std::fclose(_f); }
+        std::fputs(_path_msg, stderr);
+    }
+#endif
     auto db_open = workspace_db_->open(_ws_path);
     FT_TS(116);
     if (db_open.is_err()) {


### PR DESCRIPTION
## Summary

- Windows-only debug code (`_snprintf_s`, `_TRUNCATE`, `OutputDebugStringA`, `CreateFileA`, `HANDLE`, `DWORD`, etc.) in `TerminalShell::initialise()` was written without any platform guard, causing **13 compile errors** on macOS/Linux
- Wrapped the original Windows block in `#if defined(_WIN32)` so it compiles and behaves exactly as before on Windows
- Added an equivalent `#else` block for macOS/Linux using standard C (`std::snprintf`, `std::fopen`/`std::fputs`) that appends to `/tmp/ft_marks.txt` and echoes to `stderr`, mirroring the Windows debug intent

## Test plan

- [ ] Confirm macOS build no longer fails at `TerminalShell.cpp` (the 13 errors are gone)
- [ ] Confirm Windows build still compiles and the original debug file (`C:\Users\Tilak\AppData\Local\Temp\ft_marks.txt`) is written as before
- [ ] On macOS/Linux, verify `/tmp/ft_marks.txt` receives the workspace_db path log line on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)