### PR TITLE
fix: guard TerminalShell Windows debug output

### DIFF
--- a/fincept-qt/src/app/TerminalShell.cpp
+++ b/fincept-qt/src/app/TerminalShell.cpp
@@ -21,6 +21,8 @@
 #include <QDateTime>
 #include <QUuid>
 
+#include <cstdio>
+
 namespace fincept {
 
 namespace {
@@ -135,6 +137,7 @@ void TerminalShell::initialise() {
     FT_TS(115);
     QString _ws_path = ProfilePaths::workspace_db();
     FT_TS(1150);
+#ifdef Q_OS_WIN
     char _path_msg[512];
     _snprintf_s(_path_msg, 512, _TRUNCATE, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
     OutputDebugStringA(_path_msg);
@@ -142,6 +145,10 @@ void TerminalShell::initialise() {
         HANDLE _h = CreateFileA("C:\\Users\\Tilak\\AppData\\Local\\Temp\\ft_marks.txt", FILE_APPEND_DATA, FILE_SHARE_READ|FILE_SHARE_WRITE, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (_h != INVALID_HANDLE_VALUE) { DWORD _w; SetFilePointer(_h, 0, NULL, FILE_END); WriteFile(_h, _path_msg, (DWORD)strlen(_path_msg), &_w, NULL); CloseHandle(_h); }
     }
+#else
+    fprintf(stderr, "FT_TS workspace_db path: %s\n", _ws_path.toUtf8().constData());
+    fflush(stderr);
+#endif
     auto db_open = workspace_db_->open(_ws_path);
     FT_TS(116);
     if (db_open.is_err()) {

--- a/fincept-qt/tests/test_terminalshell_platform_guards.py
+++ b/fincept-qt/tests/test_terminalshell_platform_guards.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+WINDOWS_ONLY_TOKENS = ("_snprintf_s", "OutputDebugStringA", "CreateFileA")
+
+
+def test_terminalshell_windows_debug_calls_are_guarded():
+    source = Path(__file__).resolve().parents[1] / "src" / "app" / "TerminalShell.cpp"
+    guarded_depth = 0
+    violations = []
+
+    for line_number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("#ifdef Q_OS_WIN"):
+            guarded_depth += 1
+            continue
+        if stripped.startswith("#else") and guarded_depth:
+            guarded_depth -= 1
+            continue
+        if stripped.startswith("#endif") and guarded_depth:
+            guarded_depth -= 1
+            continue
+
+        if guarded_depth == 0 and any(token in line for token in WINDOWS_ONLY_TOKENS):
+            violations.append((line_number, line.strip()))
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- wrap TerminalShell workspace-db path tracing that uses Windows APIs in `Q_OS_WIN`
- emit the same diagnostic to stderr on non-Windows builds
- add a static regression test that catches Windows-only debug calls outside a Windows guard

## Validation
- `uv run --no-sync pytest fincept-qt/tests/test_terminalshell_platform_guards.py -q`
- `uv run --no-sync python -m py_compile fincept-qt/tests/test_terminalshell_platform_guards.py`
- `git diff --check`

I did not run a full Qt/macOS build in this Windows workspace.

Fixes #254