### PR TITLE
watchlist: add Export CSV button

### DIFF
--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
@@ -11,6 +11,8 @@
 #    include "datahub/DataHub.h"
 #    include "datahub/DataHubMetaTypes.h"
 
+#include <QFile>
+#include <QFileDialog>
 #include <QHBoxLayout>
 #include <QHideEvent>
 #include <QInputDialog>
@@ -18,6 +20,7 @@
 #include <QPointer>
 #include <QShowEvent>
 #include <QSplitter>
+#include <QTextStream>
 #include <QVBoxLayout>
 
 namespace fincept::screens {
@@ -246,7 +249,13 @@ QWidget* WatchlistScreen::build_main_panel() {
 
     del_wl_btn_ = new QPushButton("DELETE LIST");
     connect(del_wl_btn_, &QPushButton::clicked, this, &WatchlistScreen::on_delete_watchlist);
+    del_wl_btn_->setEnabled(false);
     tl->addWidget(del_wl_btn_);
+
+    export_csv_btn_ = new QPushButton("EXPORT CSV");
+    connect(export_csv_btn_, &QPushButton::clicked, this, &WatchlistScreen::on_export_csv);
+    export_csv_btn_->setEnabled(false);
+    tl->addWidget(export_csv_btn_);
 
     lay->addWidget(top_bar_);
 
@@ -379,6 +388,9 @@ void WatchlistScreen::refresh_theme() {
 
     if (del_wl_btn_)
         del_wl_btn_->setStyleSheet(danger_btn_style());
+
+    if (export_csv_btn_)
+        export_csv_btn_->setStyleSheet(std_btn_style());
 
     // Add bar
     if (add_bar_)
@@ -569,6 +581,8 @@ void WatchlistScreen::on_watchlist_selected(int row) {
     panel_title_->setText(watchlists_[row].name.toUpper());
     load_stocks();
     ScreenStateManager::instance().notify_changed(this);
+    if (del_wl_btn_) del_wl_btn_->setEnabled(true);
+    if (export_csv_btn_) export_csv_btn_->setEnabled(true);
 }
 
 void WatchlistScreen::on_add_watchlist() {
@@ -601,6 +615,8 @@ void WatchlistScreen::on_delete_watchlist() {
     table_->clear_data();
     panel_title_->setText("Select a watchlist");
     stock_count_->clear();
+    if (del_wl_btn_) del_wl_btn_->setEnabled(false);
+    if (export_csv_btn_) export_csv_btn_->setEnabled(false);
     load_watchlists();
 }
 
@@ -640,6 +656,69 @@ void WatchlistScreen::on_remove_stock() {
 void WatchlistScreen::on_refresh() {
     if (!current_wl_id_.isEmpty()) {
         fetch_quotes();
+    }
+}
+
+void WatchlistScreen::on_export_csv() {
+    if (current_wl_id_.isEmpty())
+        return;
+
+    QString wl_name;
+    for (const auto& wl : watchlists_) {
+        if (wl.id == current_wl_id_) {
+            wl_name = wl.name;
+            break;
+        }
+    }
+    
+    if (wl_name.isEmpty()) return;
+
+    const QString suggested = wl_name + QStringLiteral(".csv");
+
+    const QString path = QFileDialog::getSaveFileName(
+        this, tr("Export Watchlist to CSV"), suggested,
+        tr("CSV Files (*.csv)"));
+    if (path.isEmpty())
+        return;
+
+    QFile f(path);
+    if (!f.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, tr("Export failed"),
+                             tr("Could not open file for writing:\n%1")
+                                 .arg(path));
+        return;
+    }
+
+    QTextStream out(&f);
+    out.setEncoding(QStringConverter::Utf8);
+
+    out << "SYMBOL,NAME,PRICE,CHANGE,CHG %,HIGH,LOW,VOLUME\n";
+
+    auto csv_escape = [](const QString& s) -> QString {
+        if (s.contains(',') || s.contains('"') || s.contains('\n')) {
+            QString e = s;
+            e.replace('"', QStringLiteral("\"\""));
+            return '"' + e + '"';
+        }
+        return s;
+    };
+
+    for (const auto& s : stocks_) {
+        const auto it = row_cache_.find(s.symbol);
+        if (it == row_cache_.end()) {
+            out << csv_escape(s.symbol) << ','
+                << csv_escape(s.name) << ",,,,,,\n";
+            continue;
+        }
+        const auto& q = it.value();
+        out << csv_escape(q.symbol) << ','
+            << csv_escape(q.name.isEmpty() ? s.name : q.name) << ','
+            << QString::number(q.price, 'f', 2) << ','
+            << QString::number(q.change, 'f', 2) << ','
+            << QString::number(q.change_pct, 'f', 2) << ','
+            << QString::number(q.high, 'f', 2) << ','
+            << QString::number(q.low, 'f', 2) << ','
+            << QString::number(static_cast<qint64>(q.volume)) << '\n';
     }
 }
 

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.h
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.h
@@ -50,6 +50,7 @@ class WatchlistScreen : public QWidget, public IStatefulScreen, public IGroupLin
     void on_add_stock();
     void on_remove_stock();
     void on_refresh();
+    void on_export_csv();
     void refresh_theme();
 
   private:
@@ -88,6 +89,7 @@ class WatchlistScreen : public QWidget, public IStatefulScreen, public IGroupLin
     QLineEdit* add_input_ = nullptr;
     QPushButton* refresh_btn_ = nullptr;
     QPushButton* del_wl_btn_ = nullptr;
+    QPushButton* export_csv_btn_ = nullptr;
     QPushButton* add_btn_ = nullptr;
     QPushButton* remove_btn_ = nullptr;
     ui::DataTable* table_ = nullptr;


### PR DESCRIPTION
**Before:** 
N/A - EXPORT CSV button was missing.

**After:**
<img width="1366" height="499" alt="image" src="https://github.com/user-attachments/assets/4db57dbe-83f1-40af-a168-c6c89bd6d185" />


**Sample CSV:**
<img width="921" height="249" alt="image" src="https://github.com/user-attachments/assets/2f0adefe-53ac-485c-8c8d-7b198f9fd723" />

**Test plan:**
- [x] Open Watchlist. The EXPORT CSV button is visible and disabled (no list selected).
- [x] Pick a watchlist with several symbols. Wait a few seconds for prices to load.
- [x] Click EXPORT CSV. A Save dialog opens with default name `<watchlist-name>.csv`.
- [x] Save it. Open the file in your spreadsheet of choice — confirm headers and raw numbers.
- [x] Try a watchlist where you just added a fresh ticker (no live data yet). Row appears with empty numeric cells.
- [x] Click EXPORT CSV → press Cancel in the dialog. App should not crash, no file written.
- [x] Pick a watchlist whose name contains a comma. Filename suggested still works and saves correctly.

**Acceptance checklist**
- [x] EXPORT CSV button visible next to REFRESH / DELETE LIST.
- [x] Disabled when no watchlist is selected.
- [x] File dialog defaults to `<watchlist-name>.csv`.
- [x] Cancel works (no file, no crash).
- [x] Saved file opens cleanly in a spreadsheet.
- [x] Rows with no live data still appear (symbol + name only).
- [x] Symbols/names containing `,` or `"` are properly quoted.
- [x] Build is green on your OS.
