### PR TITLE
fix: excel csv utf-8 + dashboard clock utc/local toggleFix/excel utf8 dashboard clock

### DIFF
--- a/fincept-qt/src/screens/dashboard/DashboardToolBar.cpp
+++ b/fincept-qt/src/screens/dashboard/DashboardToolBar.cpp
@@ -64,7 +64,7 @@ DashboardToolBar::DashboardToolBar(QWidget* parent) : QWidget(parent) {
 
     make_sep(ll);
 
-   clock_btn_ = new QPushButton;
+    clock_btn_ = new QPushButton;
     clock_btn_->setObjectName("dtBtn");
     clock_btn_->setFlat(true);
     clock_btn_->setCursor(Qt::PointingHandCursor);
@@ -189,7 +189,8 @@ void DashboardToolBar::refresh_theme() {
     // Force child containers to re-evaluate their background after stylesheet change.
     // Without this, Qt may repaint them with the default palette grey on show events.
     auto repolish = [](QWidget* w) {
-        if (!w) return;
+        if (!w)
+            return;
         w->style()->unpolish(w);
         w->style()->polish(w);
         w->update();
@@ -209,13 +210,9 @@ void DashboardToolBar::showEvent(QShowEvent* event) {
 
 void DashboardToolBar::update_clock() {
     const QString suffix = clock_is_utc_ ? " UTC" : " LOC";
-    const QDateTime now  = clock_is_utc_ ? QDateTime::currentDateTimeUtc()
-                                         : QDateTime::currentDateTime();
+    const QDateTime now = clock_is_utc_ ? QDateTime::currentDateTimeUtc() : QDateTime::currentDateTime();
     clock_btn_->setText(now.toString("yyyy-MM-dd HH:mm:ss") + suffix);
 }
-    
-   
-
 
 void DashboardToolBar::set_widget_count(int count) {
     widget_count_->setText(QString("%1 WIDGETS").arg(count));

--- a/fincept-qt/src/screens/dashboard/DashboardToolBar.cpp
+++ b/fincept-qt/src/screens/dashboard/DashboardToolBar.cpp
@@ -64,9 +64,16 @@ DashboardToolBar::DashboardToolBar(QWidget* parent) : QWidget(parent) {
 
     make_sep(ll);
 
-    clock_label_ = new QLabel;
-    clock_label_->setObjectName("dtClock");
-    ll->addWidget(clock_label_);
+   clock_btn_ = new QPushButton;
+    clock_btn_->setObjectName("dtBtn");
+    clock_btn_->setFlat(true);
+    clock_btn_->setCursor(Qt::PointingHandCursor);
+    clock_btn_->setToolTip("Click to toggle UTC / local time");
+    connect(clock_btn_, &QPushButton::clicked, this, [this]() {
+        clock_is_utc_ = !clock_is_utc_;
+        update_clock();
+    });
+    ll->addWidget(clock_btn_);
     update_clock();
 
     make_sep(ll);
@@ -201,8 +208,14 @@ void DashboardToolBar::showEvent(QShowEvent* event) {
 }
 
 void DashboardToolBar::update_clock() {
-    clock_label_->setText(QDateTime::currentDateTimeUtc().toString("yyyy-MM-dd HH:mm:ss") + " UTC");
+    const QString suffix = clock_is_utc_ ? " UTC" : " LOC";
+    const QDateTime now  = clock_is_utc_ ? QDateTime::currentDateTimeUtc()
+                                         : QDateTime::currentDateTime();
+    clock_btn_->setText(now.toString("yyyy-MM-dd HH:mm:ss") + suffix);
 }
+    
+   
+
 
 void DashboardToolBar::set_widget_count(int count) {
     widget_count_->setText(QString("%1 WIDGETS").arg(count));

--- a/fincept-qt/src/screens/dashboard/DashboardToolBar.h
+++ b/fincept-qt/src/screens/dashboard/DashboardToolBar.h
@@ -36,7 +36,8 @@ class DashboardToolBar : public QWidget {
 
     QWidget* left_container_ = nullptr;
     QWidget* right_container_ = nullptr;
-    QLabel* clock_label_ = nullptr;
+    QPushButton* clock_btn_ = nullptr;
+    bool clock_is_utc_ = true;
     QLabel* status_text_ = nullptr;
     QLabel* widget_count_ = nullptr;
     QPushButton* pulse_btn_ = nullptr;

--- a/fincept-qt/src/screens/excel/ExcelScreen.cpp
+++ b/fincept-qt/src/screens/excel/ExcelScreen.cpp
@@ -332,11 +332,12 @@ void ExcelScreen::on_export_csv() {
         return;
 
     QFile file(path);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)){
-         QMessageBox::warning(this, "Export failed", "Could not open file for writing:\n" + path);
-    return;
-    }
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, "Export failed", "Could not open file for writing:\n" + path);
         return;
+    
+    }
+        
 
     QTextStream out(&file);
     out.setEncoding(QStringConverter::Utf8);

--- a/fincept-qt/src/screens/excel/ExcelScreen.cpp
+++ b/fincept-qt/src/screens/excel/ExcelScreen.cpp
@@ -17,7 +17,7 @@
 #include <QVBoxLayout>
 
 #ifdef FINCEPT_HAS_QXLSX
-#include <xlsxdocument.h>
+#    include <xlsxdocument.h>
 #endif
 
 namespace fincept::screens {
@@ -111,7 +111,8 @@ void ExcelScreen::build_ui() {
 QWidget* ExcelScreen::build_toolbar() {
     auto* bar = new QWidget(this);
     bar->setFixedHeight(40);
-    bar->setStyleSheet(QString("background:%1; border-bottom:1px solid %2;").arg(colors::BORDER_MED(), colors::TEXT_DIM()));
+    bar->setStyleSheet(
+        QString("background:%1; border-bottom:1px solid %2;").arg(colors::BORDER_MED(), colors::TEXT_DIM()));
 
     auto* hl = new QHBoxLayout(bar);
     hl->setContentsMargins(12, 0, 12, 0);
@@ -127,12 +128,12 @@ QWidget* ExcelScreen::build_toolbar() {
     auto make_btn = [&](const QString& text, const QString& tooltip = {}) -> QPushButton* {
         auto* btn = new QPushButton(text, bar);
         btn->setToolTip(tooltip);
-        btn->setStyleSheet(
-            QString("QPushButton { background:%3; color:%4; border:none;"
-                    " font-family:%1; font-size:10px; font-weight:600; padding:6px 12px; }"
-                    "QPushButton:hover { background:%5; }"
-                    "QPushButton:pressed { background:%2; }")
-                .arg(fonts::DATA_FAMILY, kAccent(), colors::TEXT_DIM(), colors::TEXT_PRIMARY(), colors::TEXT_TERTIARY()));
+        btn->setStyleSheet(QString("QPushButton { background:%3; color:%4; border:none;"
+                                   " font-family:%1; font-size:10px; font-weight:600; padding:6px 12px; }"
+                                   "QPushButton:hover { background:%5; }"
+                                   "QPushButton:pressed { background:%2; }")
+                               .arg(fonts::DATA_FAMILY, kAccent(), colors::TEXT_DIM(), colors::TEXT_PRIMARY(),
+                                    colors::TEXT_TERTIARY()));
         return btn;
     };
 
@@ -163,10 +164,11 @@ QWidget* ExcelScreen::build_toolbar() {
     hl->addWidget(rename_btn);
 
     auto* del_btn = make_btn("DELETE", "Delete current sheet");
-    del_btn->setStyleSheet(QString("QPushButton { background:%2; color:%3; border:none;"
-                                   " font-family:%1; font-size:10px; font-weight:600; padding:6px 12px; }"
-                                   "QPushButton:hover { background:%4; }")
-                               .arg(fonts::DATA_FAMILY, colors::TEXT_DIM(), colors::TEXT_PRIMARY(), colors::NEGATIVE()));
+    del_btn->setStyleSheet(
+        QString("QPushButton { background:%2; color:%3; border:none;"
+                " font-family:%1; font-size:10px; font-weight:600; padding:6px 12px; }"
+                "QPushButton:hover { background:%4; }")
+            .arg(fonts::DATA_FAMILY, colors::TEXT_DIM(), colors::TEXT_PRIMARY(), colors::NEGATIVE()));
     connect(del_btn, &QPushButton::clicked, this, &ExcelScreen::on_delete_sheet);
     hl->addWidget(del_btn);
 
@@ -245,9 +247,9 @@ void ExcelScreen::on_import() {
     services::FileManagerService::instance().import_file(path, "excel");
 #else
     QMessageBox::information(this, "Excel Import",
-        "Excel (.xlsx) import requires Qt6 private headers.\n"
-        "This build was compiled without QXlsx support.\n\n"
-        "CSV files can still be imported via the toolbar.");
+                             "Excel (.xlsx) import requires Qt6 private headers.\n"
+                             "This build was compiled without QXlsx support.\n\n"
+                             "CSV files can still be imported via the toolbar.");
 #endif
 }
 
@@ -312,9 +314,9 @@ void ExcelScreen::on_export() {
     }
 #else
     QMessageBox::information(this, "Excel Export",
-        "Excel (.xlsx) export requires Qt6 private headers.\n"
-        "This build was compiled without QXlsx support.\n\n"
-        "CSV export is still available via the toolbar.");
+                             "Excel (.xlsx) export requires Qt6 private headers.\n"
+                             "This build was compiled without QXlsx support.\n\n"
+                             "CSV export is still available via the toolbar.");
 #endif
 }
 
@@ -335,9 +337,7 @@ void ExcelScreen::on_export_csv() {
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
         QMessageBox::warning(this, "Export failed", "Could not open file for writing:\n" + path);
         return;
-    
     }
-        
 
     QTextStream out(&file);
     out.setEncoding(QStringConverter::Utf8);

--- a/fincept-qt/src/screens/excel/ExcelScreen.cpp
+++ b/fincept-qt/src/screens/excel/ExcelScreen.cpp
@@ -332,10 +332,14 @@ void ExcelScreen::on_export_csv() {
         return;
 
     QFile file(path);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)){
+         QMessageBox::warning(this, "Export failed", "Could not open file for writing:\n" + path);
+    return;
+    }
         return;
 
     QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
     auto cells = sheet->get_data();
 
     // Find the last row/col with data to avoid huge trailing empty rows


### PR DESCRIPTION
1. Excel CSV Export:
   - Added UTF-8 encoding so characters like café, €, 日本 export correctly
   - Added warning popup when file cannot be opened for writing

2. Dashboard Clock Toggle:
   - Clock is now clickable to toggle between UTC and local time
   - Hover shows pointing-hand cursor and tooltip
   - Clock still updates every second in both modes

Manual Tests:
- Task 1: café/€/日本 round-trip correctly through Export CSV
- Task 1: write-protected path shows warning instead of silent failure
- Task 2: clock click flips UTC ↔ LOC instantly
- Task 2: ticker still updates every second