### PR TITLE
gov-data: utf-8 + newline escape in shared CSV exporter

### DIFF
--- a/fincept-qt/src/screens/gov_data/GovDataProviderPanel.cpp
+++ b/fincept-qt/src/screens/gov_data/GovDataProviderPanel.cpp
@@ -17,6 +17,7 @@
 #include <QLabel>
 #include <QScrollArea>
 #include <QTextStream>
+#include <QMessageBox>
 #include <QTimer>
 #include <QUrl>
 #include <QVBoxLayout>
@@ -801,9 +802,12 @@ void export_table_to_csv(QTableWidget* table, const QString& default_name, QWidg
         return;
 
     QFile file(path);
-    if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QMessageBox::warning(parent, "Export failed", "Unable to open file for writing.");
         return;
+    }
     QTextStream out(&file);
+    out.setEncoding(QStringConverter::Utf8);
 
     QStringList headers;
     for (int c = 0; c < table->columnCount(); ++c) {
@@ -817,7 +821,7 @@ void export_table_to_csv(QTableWidget* table, const QString& default_name, QWidg
         for (int c = 0; c < table->columnCount(); ++c) {
             auto* item = table->item(r, c);
             QString val = item ? item->text() : "";
-            if (val.contains(',') || val.contains('"'))
+            if (val.contains(',') || val.contains('"') || val.contains('\n'))
                 val = "\"" + val.replace("\"", "\"\"") + "\"";
             row << val;
         }


### PR DESCRIPTION
Task 1
## Summary

Fixed multiple issues in the shared gov-data CSV export helper used across all government-data panels (France, UK, HK, Treasury, Congress, Australia, and Provider).

## Changes Made

* Added explicit UTF-8 encoding using `QStringConverter::Utf8` to ensure exported CSV files correctly preserve international characters such as French accents, Chinese characters, and German umlauts across platforms.
* Updated CSV escaping logic to properly handle cells containing newline characters (`\n`) in addition to commas and quotes, preventing malformed CSV output.
* Added `QMessageBox::warning(...)` feedback when `file.open()` fails so export errors are surfaced to the user instead of failing silently.

## User Impact

* Exported CSV files now open correctly in Excel/Numbers without character corruption such as `Ã©` instead of `é`.
* Multi-line cell content no longer breaks CSV formatting.
* Users now receive a visible warning when exporting to an invalid or write-protected path.

## Testing Performed

* Verified French CSV exports preserve accented characters correctly.
* Verified newline-containing cells remain properly escaped and readable as valid CSV.
* Verified export failure scenarios display warning dialogs instead of silently returning.
* Confirmed existing CSV export functionality remains unchanged otherwise.

## Files Modified

* `src/screens/gov_data/GovDataProviderPanel.cpp`
