### PR TITLE
ui: watchlist + markets polish (volume format, copy symbol, import csv)

### DIFF
--- a/fincept-qt/src/screens/markets/MarketPanel.cpp
+++ b/fincept-qt/src/screens/markets/MarketPanel.cpp
@@ -2,6 +2,7 @@
 
 #include "ui/theme/Theme.h"
 #include "ui/theme/ThemeManager.h"
+#include "ui/formatting/NumberFormat.h"
 
 #    include "datahub/DataHub.h"
 #    include "datahub/DataHubMetaTypes.h"
@@ -364,7 +365,7 @@ void MarketPanel::populate(const QVector<services::QuoteData>& quotes) {
             else if (col == "CHG%")   table_->setItem(row, ci, mk(QString("%1%2%").arg(arr).arg(std::abs(q.change_pct), 0, 'f', 2), cc));
             else if (col == "HIGH")   table_->setItem(row, ci, mk(QString::number(q.high, 'f', 2), ui::colors::TEXT_SECONDARY()));
             else if (col == "LOW")    table_->setItem(row, ci, mk(QString::number(q.low,  'f', 2), ui::colors::TEXT_SECONDARY()));
-            else if (col == "VOL")    table_->setItem(row, ci, mk("--", ui::colors::TEXT_DIM()));  // TODO: wire volume from API response
+            else if (col == "VOL")    table_->setItem(row, ci, mk(fincept::ui::formatting::format_compact_volume(static_cast<qint64>(q.volume)), ui::colors::TEXT_DIM()));
             else if (col == "BID")    table_->setItem(row, ci, mk("--", ui::colors::TEXT_DIM()));
             else if (col == "ASK")    table_->setItem(row, ci, mk("--", ui::colors::TEXT_DIM()));
             else if (col == "OPEN")   table_->setItem(row, ci, mk("--", ui::colors::TEXT_DIM()));

--- a/fincept-qt/src/screens/markets/MarketPanel.cpp
+++ b/fincept-qt/src/screens/markets/MarketPanel.cpp
@@ -7,6 +7,8 @@
 #    include "datahub/DataHub.h"
 #    include "datahub/DataHubMetaTypes.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QMenu>
@@ -96,6 +98,11 @@ void MarketPanel::build_ui() {
     // causing the first panel in each column to grab disproportionate space.
     table_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Ignored);
     setup_table_columns();
+    
+    table_->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(table_, &QTableWidget::customContextMenuRequested,
+            this, &MarketPanel::show_row_context_menu);
+
     table_->setVisible(false);  // hidden until first data arrives
     bl->addWidget(table_);
 
@@ -472,6 +479,21 @@ void MarketPanel::refresh_theme() {
                      ui::colors::TEXT_DIM(), ui::colors::BORDER_DIM())
                 .arg(fhdr).arg(ff));
     }
+}
+
+void MarketPanel::show_row_context_menu(const QPoint& pos) {
+    auto* it = table_->itemAt(pos);
+    if (!it) return;
+
+    QMenu menu(this);
+    QAction* copy_act = menu.addAction("Copy Symbol");
+    connect(copy_act, &QAction::triggered, this, [this, it]() {
+        auto* sym_item = table_->item(it->row(), 0);
+        if (sym_item) {
+            QApplication::clipboard()->setText(sym_item->text());
+        }
+    });
+    menu.exec(table_->viewport()->mapToGlobal(pos));
 }
 
 } // namespace fincept::screens

--- a/fincept-qt/src/screens/markets/MarketPanel.h
+++ b/fincept-qt/src/screens/markets/MarketPanel.h
@@ -57,6 +57,7 @@ class MarketPanel : public QWidget {
     void tick_loading_anim();
     void refresh_theme();
     void open_cols_dropdown();
+    void show_row_context_menu(const QPoint& pos);
 
     void hub_resubscribe();
     void hub_unsubscribe_all();

--- a/fincept-qt/src/screens/markets/MarketPanel.h
+++ b/fincept-qt/src/screens/markets/MarketPanel.h
@@ -45,6 +45,9 @@ class MarketPanel : public QWidget {
   protected:
     void resizeEvent(QResizeEvent* event) override;
 
+  private slots:
+    void show_row_context_menu(const QPoint& pos);
+
   private:
     void build_ui();
     void setup_table_columns();
@@ -57,7 +60,6 @@ class MarketPanel : public QWidget {
     void tick_loading_anim();
     void refresh_theme();
     void open_cols_dropdown();
-    void show_row_context_menu(const QPoint& pos);
 
     void hub_resubscribe();
     void hub_unsubscribe_all();

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
@@ -7,6 +7,7 @@
 #include "core/symbol/SymbolDragSource.h"
 #include "ui/theme/Theme.h"
 #include "ui/theme/ThemeManager.h"
+#include "ui/formatting/NumberFormat.h"
 
 #    include "datahub/DataHub.h"
 #    include "datahub/DataHubMetaTypes.h"
@@ -559,7 +560,7 @@ void WatchlistScreen::populate_table(const QVector<services::QuoteData>& quotes)
                              QString("%1%2").arg(q.change >= 0 ? "+" : "").arg(q.change, 0, 'f', 2),
                              QString("%1%2%").arg(q.change_pct >= 0 ? "+" : "").arg(q.change_pct, 0, 'f', 2),
                              QString("$%1").arg(q.high, 0, 'f', 2), QString("$%1").arg(q.low, 0, 'f', 2),
-                             QString::number(static_cast<qint64>(q.volume))});
+                             fincept::ui::formatting::format_compact_volume(static_cast<qint64>(q.volume))});
 
             int row = table_->rowCount() - 1;
             // Green = good, Red = bad
@@ -718,7 +719,7 @@ void WatchlistScreen::on_export_csv() {
             << QString::number(q.change_pct, 'f', 2) << ','
             << QString::number(q.high, 'f', 2) << ','
             << QString::number(q.low, 'f', 2) << ','
-            << QString::number(static_cast<qint64>(q.volume)) << '\n';
+            << fincept::ui::formatting::format_compact_volume(static_cast<qint64>(q.volume)) << '\n';
     }
 }
 

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
@@ -19,6 +19,7 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QPointer>
+#include <QSet>
 #include <QShowEvent>
 #include <QSplitter>
 #include <QTextStream>
@@ -791,15 +792,18 @@ void WatchlistScreen::on_import_csv() {
         return;
     }
 
+    auto& repo = fincept::WatchlistRepository::instance();
+
     QSet<QString> existing;
-    for (const auto& s : stocks_) {
-        existing.insert(s.symbol.trimmed().toUpper());
+    auto stocks_res = repo.get_stocks(current_wl_id_);
+    if (stocks_res.is_ok()) {
+        for (const auto& s : stocks_res.value()) {
+            existing.insert(s.symbol.trimmed().toUpper());
+        }
     }
 
     int imported = 0;
     int skipped = 0;
-
-    auto& repo = fincept::WatchlistRepository::instance();
 
     while (!in.atEnd()) {
         QString line = in.readLine();
@@ -827,7 +831,9 @@ void WatchlistScreen::on_import_csv() {
         imported++;
     }
 
-    load_stocks();
+    if (wl_list_) {
+        on_watchlist_selected(wl_list_->currentRow());
+    }
 
     QMessageBox::information(this, tr("Import Complete"),
                              tr("Imported %1, skipped %2 duplicates.")

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
@@ -253,6 +253,11 @@ QWidget* WatchlistScreen::build_main_panel() {
     del_wl_btn_->setEnabled(false);
     tl->addWidget(del_wl_btn_);
 
+    import_csv_btn_ = new QPushButton("IMPORT CSV");
+    connect(import_csv_btn_, &QPushButton::clicked, this, &WatchlistScreen::on_import_csv);
+    import_csv_btn_->setEnabled(false);
+    tl->addWidget(import_csv_btn_);
+
     export_csv_btn_ = new QPushButton("EXPORT CSV");
     connect(export_csv_btn_, &QPushButton::clicked, this, &WatchlistScreen::on_export_csv);
     export_csv_btn_->setEnabled(false);
@@ -389,6 +394,9 @@ void WatchlistScreen::refresh_theme() {
 
     if (del_wl_btn_)
         del_wl_btn_->setStyleSheet(danger_btn_style());
+
+    if (import_csv_btn_)
+        import_csv_btn_->setStyleSheet(std_btn_style());
 
     if (export_csv_btn_)
         export_csv_btn_->setStyleSheet(std_btn_style());
@@ -583,6 +591,7 @@ void WatchlistScreen::on_watchlist_selected(int row) {
     load_stocks();
     ScreenStateManager::instance().notify_changed(this);
     if (del_wl_btn_) del_wl_btn_->setEnabled(true);
+    if (import_csv_btn_) import_csv_btn_->setEnabled(true);
     if (export_csv_btn_) export_csv_btn_->setEnabled(true);
 }
 
@@ -617,6 +626,7 @@ void WatchlistScreen::on_delete_watchlist() {
     panel_title_->setText("Select a watchlist");
     stock_count_->clear();
     if (del_wl_btn_) del_wl_btn_->setEnabled(false);
+    if (import_csv_btn_) import_csv_btn_->setEnabled(false);
     if (export_csv_btn_) export_csv_btn_->setEnabled(false);
     load_watchlists();
 }
@@ -721,6 +731,107 @@ void WatchlistScreen::on_export_csv() {
             << QString::number(q.low, 'f', 2) << ','
             << fincept::ui::formatting::format_compact_volume(static_cast<qint64>(q.volume)) << '\n';
     }
+}
+
+void WatchlistScreen::on_import_csv() {
+    if (current_wl_id_.isEmpty()) return;
+
+    const QString path = QFileDialog::getOpenFileName(
+        this, tr("Import CSV"), "", tr("CSV Files (*.csv)"));
+    if (path.isEmpty()) return;
+
+    QFile f(path);
+    if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QMessageBox::warning(this, tr("Import failed"),
+                             tr("Could not open file for reading:\n%1").arg(path));
+        return;
+    }
+
+    QTextStream in(&f);
+    in.setEncoding(QStringConverter::Utf8);
+
+    QString header_line = in.readLine();
+    if (header_line.isEmpty()) return;
+
+    auto parse_csv_line = [](const QString& line) -> QStringList {
+        QStringList fields;
+        QString current;
+        bool in_quotes = false;
+        for (int i = 0; i < line.length(); ++i) {
+            QChar c = line[i];
+            if (c == '"') {
+                if (i + 1 < line.length() && line[i+1] == '"') {
+                    current += '"';
+                    ++i;
+                } else {
+                    in_quotes = !in_quotes;
+                }
+            } else if (c == ',' && !in_quotes) {
+                fields.append(current);
+                current.clear();
+            } else {
+                current += c;
+            }
+        }
+        fields.append(current);
+        return fields;
+    };
+
+    QStringList headers = parse_csv_line(header_line);
+    int sym_col = -1;
+    int name_col = -1;
+    for (int i = 0; i < headers.size(); ++i) {
+        QString h = headers[i].trimmed().toUpper();
+        if (h == "SYMBOL") sym_col = i;
+        else if (h == "NAME") name_col = i;
+    }
+
+    if (sym_col == -1) {
+        QMessageBox::warning(this, tr("Import failed"), tr("CSV missing SYMBOL column."));
+        return;
+    }
+
+    QSet<QString> existing;
+    for (const auto& s : stocks_) {
+        existing.insert(s.symbol.trimmed().toUpper());
+    }
+
+    int imported = 0;
+    int skipped = 0;
+
+    auto& repo = fincept::WatchlistRepository::instance();
+
+    while (!in.atEnd()) {
+        QString line = in.readLine();
+        if (line.trimmed().isEmpty()) continue;
+
+        QStringList fields = parse_csv_line(line);
+        if (fields.size() <= sym_col) continue;
+
+        QString sym = fields[sym_col].trimmed();
+        if (sym.isEmpty()) continue;
+
+        QString upper_sym = sym.toUpper();
+        if (existing.contains(upper_sym)) {
+            skipped++;
+            continue;
+        }
+
+        QString name = "";
+        if (name_col != -1 && fields.size() > name_col) {
+            name = fields[name_col].trimmed();
+        }
+
+        repo.add_stock(current_wl_id_, sym, name);
+        existing.insert(upper_sym);
+        imported++;
+    }
+
+    load_stocks();
+
+    QMessageBox::information(this, tr("Import Complete"),
+                             tr("Imported %1, skipped %2 duplicates.")
+                             .arg(imported).arg(skipped));
 }
 
 // ── IStatefulScreen ───────────────────────────────────────────────────────────

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.h
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.h
@@ -51,6 +51,7 @@ class WatchlistScreen : public QWidget, public IStatefulScreen, public IGroupLin
     void on_remove_stock();
     void on_refresh();
     void on_export_csv();
+    void on_import_csv();
     void refresh_theme();
 
   private:
@@ -90,6 +91,7 @@ class WatchlistScreen : public QWidget, public IStatefulScreen, public IGroupLin
     QPushButton* refresh_btn_ = nullptr;
     QPushButton* del_wl_btn_ = nullptr;
     QPushButton* export_csv_btn_ = nullptr;
+    QPushButton* import_csv_btn_ = nullptr;
     QPushButton* add_btn_ = nullptr;
     QPushButton* remove_btn_ = nullptr;
     ui::DataTable* table_ = nullptr;

--- a/fincept-qt/src/ui/formatting/NumberFormat.h
+++ b/fincept-qt/src/ui/formatting/NumberFormat.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <QString>
+
+namespace fincept::ui::formatting {
+
+inline QString format_compact_volume(qint64 volume) {
+    if (volume <= 0) return "--";
+    double v = static_cast<double>(volume);
+    if (v >= 1e9) {
+        return QString::number(v / 1e9, 'f', 2) + "B";
+    } else if (v >= 1e6) {
+        return QString::number(v / 1e6, 'f', 2) + "M";
+    } else if (v >= 1e3) {
+        return QString::number(v / 1e3, 'f', 2) + "K";
+    } else {
+        return QString::number(volume);
+    }
+}
+
+} // namespace fincept::ui::formatting


### PR DESCRIPTION
### User-Visible Changes:
- **Watchlist & Markets Volume Formatting:** Volume numbers across the Watchlist and Market panels (as well as CSV exports) now render compactly (e.g., `12.35M` or `1.2K`) instead of large raw integers.
- **Markets Copy Symbol:** Added a right-click context menu to the Markets table featuring a "Copy Symbol" action to quickly copy a row's ticker to the system clipboard.
- **Watchlist CSV Import:** Added an "IMPORT CSV" button to Watchlists that parses the export format (including quoted names), adds new tickers, and silently skips any duplicates.

### Manual Test Results:
- **Task 1:** Checked watchlist symbols; volume renders compactly (e.g., `12.35M`). Exported to CSV and verified the volume column matches the compact form.
- **Task 2:** Right-clicked a market row, triggered the "Copy Symbol" action, and verified the correct ticker pastes successfully. Verified that right-clicking an empty space does not cause a crash.
- **Task 3:** Exported a watchlist and successfully imported it back with zero duplicates. Tested hand-adding a row to the CSV and successfully imported just the new row. Tested importing `"Foo, Inc."` and it mapped correctly. Verified that importing a CSV without a `SYMBOL` header correctly displays a warning popup.
