### PR TITLE
Fix/data quality batch

### DIFF
--- a/fincept-qt/src/screens/equity_trading/EquityBottomPanel.cpp
+++ b/fincept-qt/src/screens/equity_trading/EquityBottomPanel.cpp
@@ -55,7 +55,7 @@ void EquityBottomPanel::setup_positions_tab() {
     positions_table_->setObjectName("eqTable");
     positions_table_->setColumnCount(8);
     positions_table_->setHorizontalHeaderLabels(
-        {"Symbol", "Exchange", "Side", "Qty", "Avg Price", "LTP", "P&L", "P&L %"});
+        {"Symbol", "Opened", "Side", "Qty", "Avg Price", "LTP", "P&L", "P&L %"});
     positions_table_->verticalHeader()->setVisible(false);
     positions_table_->setSelectionBehavior(QAbstractItemView::SelectRows);
     positions_table_->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -232,16 +232,34 @@ void EquityBottomPanel::set_paper_positions(const QVector<trading::PtPosition>& 
     for (int i = 0; i < positions.size(); ++i) {
         const auto& p = positions[i];
         ensure_item(positions_table_, i, 0)->setText(p.symbol);
-        ensure_item(positions_table_, i, 1)->setText("--");
+
+        // Col 1 — "Opened": format ISO timestamp; fall back to raw string on parse failure
+        {
+            const QDateTime dt = QDateTime::fromString(p.opened_at, Qt::ISODate);
+            ensure_item(positions_table_, i, 1)
+                ->setText(dt.isValid() ? dt.toString("yyyy-MM-dd HH:mm") : p.opened_at);
+        }
+
         ensure_item(positions_table_, i, 2)->setText(p.side);
         ensure_item(positions_table_, i, 3)->setText(QString::number(p.quantity, 'f', 0));
         ensure_item(positions_table_, i, 4)->setText(QString::number(p.entry_price, 'f', 2));
         ensure_item(positions_table_, i, 5)->setText(QString::number(p.current_price, 'f', 2));
 
+        // Col 6 — P&L
         auto* pnl_item = ensure_item(positions_table_, i, 6);
         pnl_item->setText(QString::number(p.unrealized_pnl, 'f', 2));
         pnl_item->setForeground(p.unrealized_pnl >= 0 ? QColor(fincept::ui::colors::POSITIVE())
                                                       : QColor(fincept::ui::colors::NEGATIVE()));
+
+        // Col 7 — P&L %
+        const double pct = p.entry_price > 0
+            ? (p.unrealized_pnl / (p.entry_price * p.quantity)) * 100.0
+            : 0.0;
+        auto* pct_item = ensure_item(positions_table_, i, 7);
+        pct_item->setText(QString::number(pct, 'f', 2) + "%");
+        pct_item->setForeground(
+            pct >= 0 ? QColor(fincept::ui::colors::POSITIVE())
+                     : QColor(fincept::ui::colors::NEGATIVE()));
     }
 }
 

--- a/fincept-qt/src/screens/equity_trading/EquityBottomPanel.cpp
+++ b/fincept-qt/src/screens/equity_trading/EquityBottomPanel.cpp
@@ -233,9 +233,9 @@ void EquityBottomPanel::set_paper_positions(const QVector<trading::PtPosition>& 
         const auto& p = positions[i];
         ensure_item(positions_table_, i, 0)->setText(p.symbol);
 
-        // Col 1 — "Opened": format ISO timestamp; fall back to raw string on parse failure
+        // Col 1 — "Opened": parse ISO timestamp, convert to local time, fall back to raw string
         {
-            const QDateTime dt = QDateTime::fromString(p.opened_at, Qt::ISODate);
+            const QDateTime dt = QDateTime::fromString(p.opened_at, Qt::ISODate).toLocalTime();
             ensure_item(positions_table_, i, 1)
                 ->setText(dt.isValid() ? dt.toString("yyyy-MM-dd HH:mm") : p.opened_at);
         }
@@ -252,8 +252,11 @@ void EquityBottomPanel::set_paper_positions(const QVector<trading::PtPosition>& 
                                                       : QColor(fincept::ui::colors::NEGATIVE()));
 
         // Col 7 — P&L %
-        const double pct = p.entry_price > 0
-            ? (p.unrealized_pnl / (p.entry_price * p.quantity)) * 100.0
+        // Use notional as the divisor so both entry_price == 0 and quantity == 0
+        // are safely handled by a single guard (avoids divide-by-zero).
+        const double notional = p.entry_price * p.quantity;
+        const double pct = notional != 0.0
+            ? (p.unrealized_pnl / notional) * 100.0
             : 0.0;
         auto* pct_item = ensure_item(positions_table_, i, 7);
         pct_item->setText(QString::number(pct, 'f', 2) + "%");

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
@@ -296,6 +296,7 @@ QWidget* WatchlistScreen::build_main_panel() {
     table_ = new ui::DataTable;
     table_->set_headers({"SYMBOL", "NAME", "PRICE", "CHANGE", "CHG %", "HIGH", "LOW", "VOLUME"});
     table_->set_column_widths({100, 160, 100, 90, 80, 90, 90, 110});
+    table_->setSortingEnabled(true); // opt-in: WatchlistScreen stamps numeric EditRole values
     table_->setSelectionBehavior(QAbstractItemView::SelectRows);
     table_->setSelectionMode(QAbstractItemView::SingleSelection);
 

--- a/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
+++ b/fincept-qt/src/screens/watchlist/WatchlistScreen.cpp
@@ -500,10 +500,12 @@ void WatchlistScreen::rebuild_from_cache() {
     }
     if (quotes.isEmpty()) {
         // No data yet — show placeholder rows.
+        table_->setSortingEnabled(false);
         table_->clear_data();
         for (const auto& s : stocks_) {
             table_->add_row({s.symbol, s.name, "--", "--", "--", "--", "--", "--"});
         }
+        table_->setSortingEnabled(true);
         return;
     }
     populate_table(quotes);
@@ -553,6 +555,9 @@ void WatchlistScreen::hub_unsubscribe_all() {
 
 
 void WatchlistScreen::populate_table(const QVector<services::QuoteData>& quotes) {
+    // Disable sorting during population to prevent per-row re-sorting
+    // (avoids both visual flickering and O(n log n) overhead per insert).
+    table_->setSortingEnabled(false);
     table_->clear_data();
 
     // Build a map for quick lookup
@@ -565,13 +570,25 @@ void WatchlistScreen::populate_table(const QVector<services::QuoteData>& quotes)
         auto it = quote_map.find(s.symbol);
         if (it != quote_map.end()) {
             const auto& q = it.value();
-            table_->add_row({q.symbol, q.name.isEmpty() ? s.name : q.name, QString("$%1").arg(q.price, 0, 'f', 2),
+            table_->add_row({q.symbol, q.name.isEmpty() ? s.name : q.name,
+                             QString("$%1").arg(q.price, 0, 'f', 2),
                              QString("%1%2").arg(q.change >= 0 ? "+" : "").arg(q.change, 0, 'f', 2),
                              QString("%1%2%").arg(q.change_pct >= 0 ? "+" : "").arg(q.change_pct, 0, 'f', 2),
-                             QString("$%1").arg(q.high, 0, 'f', 2), QString("$%1").arg(q.low, 0, 'f', 2),
+                             QString("$%1").arg(q.high, 0, 'f', 2),
+                             QString("$%1").arg(q.low, 0, 'f', 2),
                              fincept::ui::formatting::format_compact_volume(static_cast<qint64>(q.volume))});
 
             int row = table_->rowCount() - 1;
+
+            // Stamp numeric EditRole values so Qt sorts by magnitude,
+            // not by the display string ("$2.5M" vs "$999K" etc.).
+            table_->set_cell_numeric(row, 2, q.price);       // PRICE
+            table_->set_cell_numeric(row, 3, q.change);      // CHANGE
+            table_->set_cell_numeric(row, 4, q.change_pct);  // CHG %
+            table_->set_cell_numeric(row, 5, q.high);        // HIGH
+            table_->set_cell_numeric(row, 6, q.low);         // LOW
+            table_->set_cell_numeric(row, 7, q.volume);      // VOLUME
+
             // Green = good, Red = bad
             QString chg_color = q.change_pct >= 0 ? colors::POSITIVE : colors::NEGATIVE;
             table_->set_cell_color(row, 3, chg_color);
@@ -580,6 +597,9 @@ void WatchlistScreen::populate_table(const QVector<services::QuoteData>& quotes)
             table_->add_row({s.symbol, s.name, "--", "--", "--", "--", "--", "--"});
         }
     }
+
+    // Re-enable sorting — Qt will apply the current sort column/order once.
+    table_->setSortingEnabled(true);
 }
 
 // ── Slots ────────────────────────────────────────────────────────────────────

--- a/fincept-qt/src/ui/tables/DataTable.cpp
+++ b/fincept-qt/src/ui/tables/DataTable.cpp
@@ -15,6 +15,11 @@ DataTable::DataTable(QWidget* parent) : QTableWidget(parent) {
     verticalHeader()->setVisible(false);
     horizontalHeader()->setStretchLastSection(true);
     horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+    // NOTE: sorting is intentionally NOT enabled here.
+    // Callers that need sorting (e.g. WatchlistScreen) opt in with
+    // setSortingEnabled(true) after attaching numeric EditRole values.
+    // Enabling it globally causes lexicographic sort on tables that only
+    // use setText() — e.g. "$10" sorts before "$2", "100K" before "2M".
     setStyleSheet(QString("QTableWidget { background: %1; alternate-background-color: %2; "
                           "gridline-color: %3; border: none; }"
                           "QTableWidget::item { padding: 4px 8px; height: 26px; }"
@@ -59,6 +64,12 @@ void DataTable::set_cell_color(int row, int col, const QString& color) {
     auto* it = item(row, col);
     if (it)
         it->setForeground(QColor(color));
+}
+
+void DataTable::set_cell_numeric(int row, int col, double value) {
+    auto* it = item(row, col);
+    if (it)
+        it->setData(Qt::EditRole, value);
 }
 
 } // namespace fincept::ui

--- a/fincept-qt/src/ui/tables/DataTable.h
+++ b/fincept-qt/src/ui/tables/DataTable.h
@@ -19,6 +19,11 @@ class DataTable : public QTableWidget {
 
     // Color a specific cell
     void set_cell_color(int row, int col, const QString& color);
+
+    /// Set a numeric sort key on a cell without changing its display text.
+    /// Call after add_row() for columns that should sort numerically
+    /// (price, change, volume, etc.).
+    void set_cell_numeric(int row, int col, double value);
 };
 
 } // namespace fincept::ui


### PR DESCRIPTION
## Changes

### Task 1 — equity: wire positions P&L% and replace dead Exchange column with Opened
- Renamed `Exchange` column header → `Opened` in the positions table
- Replaced hardcoded `"--"` with formatted `opened_at` timestamp (ISO → local time, `yyyy-MM-dd HH:mm`)
- Populated P&L % column (col 7) with `(unrealized_pnl / notional) * 100`, coloured green/red

### Task 2 — watchlist: sortable column headers with numeric sort role
- `DataTable`: added `set_cell_numeric()` helper — stamps `Qt::EditRole` double for correct numeric sort
- Sorting NOT enabled globally (per review); WatchlistScreen opts in explicitly
- `populate_table()` stamps numeric values for PRICE, CHANGE, CHG%, HIGH, LOW, VOLUME
- Population wrapped with `setSortingEnabled(false/true)` to prevent per-row re-sort flickering
- VOLUME display uses `format_compact_volume()` (from #280); sort key uses raw `double`

### Review fixes
- Reverted `setSortingEnabled(true)` from `DataTable` constructor
- Fixed P&L% divide-by-zero: guard uses `notional != 0.0` (covers `quantity == 0` too)
- Added `.toLocalTime()` on `opened_at` parse for timezone consistency
