### PR TITLE
fix(equity): fix holdings table sorting bug by using EditRole

### DIFF
--- a/fincept-qt/src/screens/equity_trading/EquityBottomPanel.cpp
+++ b/fincept-qt/src/screens/equity_trading/EquityBottomPanel.cpp
@@ -350,7 +350,7 @@ void EquityBottomPanel::set_holdings(const QVector<trading::BrokerHolding>& hold
 
     auto set_num = [](QTableWidgetItem* it, double v, int precision) {
         it->setData(Qt::DisplayRole, QString::number(v, 'f', precision));
-        it->setData(Qt::UserRole, v); // for potential custom sort; Display still orders alphabetically
+        it->setData(Qt::EditRole, v);
     };
 
     for (int i = 0; i < holdings.size(); ++i) {
@@ -363,11 +363,13 @@ void EquityBottomPanel::set_holdings(const QVector<trading::BrokerHolding>& hold
         set_num(ensure_item(holdings_table_, i, 5), h.current_value, 2);
 
         auto* pnl_item = ensure_item(holdings_table_, i, 6);
-        pnl_item->setText(QString::number(h.pnl, 'f', 2));
+        pnl_item->setData(Qt::DisplayRole, QString::number(h.pnl, 'f', 2));
+        pnl_item->setData(Qt::EditRole, h.pnl);
         pnl_item->setForeground(h.pnl >= 0 ? pos_color : neg_color);
 
         auto* pct_item = ensure_item(holdings_table_, i, 7);
-        pct_item->setText(QString("%1%").arg(h.pnl_pct, 0, 'f', 2));
+        pct_item->setData(Qt::DisplayRole, QString("%1%").arg(h.pnl_pct, 0, 'f', 2));
+        pct_item->setData(Qt::EditRole, h.pnl_pct);
         pct_item->setForeground(h.pnl_pct >= 0 ? pos_color : neg_color);
 
         total_invested += h.invested_value;


### PR DESCRIPTION
Closes #<your-issue-number>

## What
Fixed lexicographic sorting in the Broker Holdings table under
EquityBottomPanel in the Equity Trading Screen.

## Why
QTableWidgetItem::operator< falls back to Qt::DisplayRole (formatted
string) when Qt::EditRole is not set, causing string-based comparison
instead of numeric.

## How
- Updated set_num lambda to store raw double on Qt::EditRole instead
  of Qt::UserRole
- Updated P&L and P&L % cells to use setData(Qt::EditRole, rawDouble)
  alongside setData(Qt::DisplayRole, formattedString)
- Aligns with the existing pattern in WatchlistScreen via
  DataTable::set_cell_numeric

## Testing
- Verified ascending/descending sort on Qty, Avg Price, LTP,
  Invested, Current, P&L, P&L % columns all sort numerically