### PR TITLE
Fix/settings uniqueconnection warning

### DIFF
--- a/fincept-qt/src/screens/settings/AppearanceSection.cpp
+++ b/fincept-qt/src/screens/settings/AppearanceSection.cpp
@@ -118,10 +118,8 @@ void AppearanceSection::build_ui() {
     });
 
     auto restart_debounce = [this]() { appearance_debounce_->start(); };
-    connect(app_font_size_,   &QComboBox::currentTextChanged, this, restart_debounce,
-            Qt::UniqueConnection);
-    connect(app_font_family_, &QComboBox::currentTextChanged, this, restart_debounce,
-            Qt::UniqueConnection);
+    connect(app_font_size_,   &QComboBox::currentTextChanged, this, restart_debounce);
+    connect(app_font_family_, &QComboBox::currentTextChanged, this, restart_debounce);
 
     vl->addSpacing(8);
     vl->addWidget(make_sep());
@@ -139,8 +137,7 @@ void AppearanceSection::build_ui() {
     app_density_->setStyleSheet(combo_ss());
     vl->addWidget(make_row("Content Density", app_density_, "Controls padding and spacing throughout the UI."));
 
-    connect(app_density_, &QComboBox::currentTextChanged, this, restart_debounce,
-            Qt::UniqueConnection);
+    connect(app_density_, &QComboBox::currentTextChanged, this, restart_debounce);
 
     vl->addSpacing(8);
     vl->addWidget(make_sep());

--- a/fincept-qt/src/services/file_manager/FileManagerService.cpp
+++ b/fincept-qt/src/services/file_manager/FileManagerService.cpp
@@ -16,6 +16,21 @@
 namespace fincept::services {
 
 static constexpr const char* kFileManagerTag = "FileManagerService";
+static bool is_safe_basename(const QString& s) {
+    if (s.isEmpty() || s == "." || s == "..")
+        return false;
+
+    if (s.contains('/') || s.contains('\\'))
+        return false;
+
+    if (s.contains(QLatin1String("..")))
+        return false;
+
+    if (QFileInfo(s).fileName() != s)
+        return false;
+
+    return true;
+}
 
 // ── Singleton ────────────────────────────────────────────────────────────────
 
@@ -37,7 +52,19 @@ QString FileManagerService::storage_dir() const {
 }
 
 QString FileManagerService::full_path(const QString& stored_name) const {
-    return storage_dir() + "/" + stored_name;
+    if (!is_safe_basename(stored_name))
+        return {};
+
+    const QString resolved =
+        QDir(storage_dir()).absoluteFilePath(stored_name);
+
+    const QString root =
+        QDir(storage_dir()).absolutePath() + '/';
+
+    if (!resolved.startsWith(root))
+        return {};
+
+    return resolved;
 }
 
 QString FileManagerService::metadata_path() const {
@@ -171,6 +198,12 @@ QString FileManagerService::import_file(const QString& source_path, const QStrin
 
 QString FileManagerService::register_file(const QString& stored_name, const QString& original_name, qint64 size,
                                           const QString& mime_type, const QString& source_screen) {
+    if (!is_safe_basename(stored_name)) {
+        LOG_WARN(kFileManagerTag,
+                 QString("Rejected unsafe stored_name: %1").arg(stored_name));
+        return {};
+    }
+
     QString id =
         QString::number(QDateTime::currentMSecsSinceEpoch()) + "_" + QUuid::createUuid().toString(QUuid::Id128).left(8);
 

--- a/fincept-qt/src/services/updater/UpdateService.cpp
+++ b/fincept-qt/src/services/updater/UpdateService.cpp
@@ -367,7 +367,7 @@ void UpdateService::on_download_reply_finished() {
             return;
         }
         LOG_INFO("UpdateService", QString("Sha256 verified: %1").arg(actual));
-    }else{
+    } else {
         LOG_ERROR("UpdateService",
                 "Manifest missing sha256 — refusing to launch installer");
         show_error(QStringLiteral(

--- a/fincept-qt/src/services/updater/UpdateService.cpp
+++ b/fincept-qt/src/services/updater/UpdateService.cpp
@@ -367,8 +367,14 @@ void UpdateService::on_download_reply_finished() {
             return;
         }
         LOG_INFO("UpdateService", QString("Sha256 verified: %1").arg(actual));
-    } else {
-        LOG_WARN("UpdateService", "No sha256 in manifest — skipping integrity verification");
+    }else{
+        LOG_ERROR("UpdateService",
+                "Manifest missing sha256 — refusing to launch installer");
+        show_error(QStringLiteral(
+            "This update cannot be verified (missing checksum). Aborting."));
+        QFile::remove(pending_local_path_);
+        finish_check(true);
+        return;
     }
 
     emit download_finished(pending_local_path_);


### PR DESCRIPTION
Fixes a runtime assertion triggered when opening the Settings screen.

The issue was caused by using Qt::UniqueConnection with lambda-based slots in AppearanceSection.cpp. Qt::UniqueConnection requires member-function slots and raises a runtime assertion with lambda callbacks.

Removed Qt::UniqueConnection from the debounce-related signal connections since these connections are initialized only once during UI setup.