### PR TITLE
feat: add Astraflow provider support (global and China endpoints)

### DIFF
--- a/fincept-qt/src/screens/settings/LlmConfigSection.cpp
+++ b/fincept-qt/src/screens/settings/LlmConfigSection.cpp
@@ -34,7 +34,8 @@ static constexpr const char* TAG = "LlmConfigSection";
 
 
 const QStringList LlmConfigSection::KNOWN_PROVIDERS = {"openai",  "anthropic", "gemini",   "groq",  "deepseek",
-                                                       "openrouter", "minimax", "kimi", "ollama", "xai",   "fincept"};
+                                                       "openrouter", "minimax", "kimi", "ollama", "xai",   "fincept",
+                                                       "astraflow", "astraflow_cn"};
 
 QString LlmConfigSection::default_base_url(const QString& provider) {
     const QString p = provider.toLower();
@@ -60,6 +61,10 @@ QString LlmConfigSection::default_base_url(const QString& provider) {
         return {};
     if (p == "fincept")
         return {}; // endpoints are hardcoded in LlmService, no base_url needed
+    if (p == "astraflow")
+        return "https://api-us-ca.umodelverse.ai/v1"; // Astraflow global endpoint (UCloud)
+    if (p == "astraflow_cn")
+        return "https://api.modelverse.cn/v1"; // Astraflow China endpoint (UCloud)
     return {};
 }
 
@@ -102,6 +107,14 @@ QStringList LlmConfigSection::fallback_models(const QString& provider) {
         return {"grok-4-latest", "grok-4", "grok-3", "grok-3-mini"};
     if (p == "fincept")
         return {"MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed"};
+    if (p == "astraflow" || p == "astraflow_cn")
+        // Astraflow by UCloud — OpenAI-compatible aggregator supporting 200+ models.
+        // A non-exhaustive starter list; full list fetchable via Fetch button.
+        return {"gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "o3-mini",
+                "claude-sonnet-4-5-20250514", "claude-3-5-sonnet-20241022",
+                "gemini-2.5-flash", "gemini-2.5-pro",
+                "deepseek-chat", "deepseek-reasoner",
+                "llama-3.3-70b-versatile", "qwen-turbo", "qwen-plus"};
     return {};
 }
 

--- a/fincept-qt/src/services/llm/ModelCatalog.cpp
+++ b/fincept-qt/src/services/llm/ModelCatalog.cpp
@@ -146,6 +146,13 @@ const CatalogEntry kCatalog[] = {
     // typical local setup.
     {"ollama", "*", 4096},
 
+    // ── Astraflow (UCloud — OpenAI-compatible aggregator) ───────────────────
+    // https://astraflow.ucloud-global.com  /  https://astraflow.ucloud.cn
+    // Supports 200+ models; output cap varies by underlying model. Use a
+    // generous default; user can override via max_tokens.
+    {"astraflow",    "*", kNoPublishedCap},
+    {"astraflow_cn", "*", kNoPublishedCap},
+
     // ── Fincept (proxies upstream) ──────────────────────────────────────
     // Fincept's /research/llm/async wraps various upstream models. We
     // don't know which one is selected server-side, so go with a generous


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider in the FinceptTerminal Qt application.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, offered through both a global and a China endpoint.

- **Global endpoint:** `https://api-us-ca.umodelverse.ai/v1` — provider key `astraflow`
- **China endpoint:**  `https://api.modelverse.cn/v1`         — provider key `astraflow_cn`
- **API key signup:** https://astraflow.ucloud-global.com (global) / https://astraflow.ucloud.cn (China)

## Changes

### `fincept-qt/src/screens/settings/LlmConfigSection.cpp`

1. **`KNOWN_PROVIDERS`** — appended `"astraflow"` and `"astraflow_cn"` so both providers appear in the *Add Provider* dialog.

2. **`default_base_url()`** — added two cases that pre-fill the correct base URL when the user adds either provider variant, matching the existing pattern used for `ollama`, `minimax`, etc.

3. **`fallback_models()`** — added a starter model list for both provider keys (identical, since the same catalogue is available on both endpoints). A non-exhaustive but representative set of the most popular models; users can also hit *Fetch* to pull the live list.

### `fincept-qt/src/services/llm/ModelCatalog.cpp`

4. **`kCatalog[]`** — added catch-all entries for `"astraflow"` and `"astraflow_cn"` using `kNoPublishedCap`, consistent with the treatment of OpenRouter and Fincept (pass-through aggregators whose per-model output cap depends on the underlying model, not the proxy).

## Why minimum viable

- **No new SDK** — Astraflow is fully OpenAI-compatible; `LlmService` already supports any provider through `base_url` + `api_key`.
- **No new files** — all changes are additive entries in existing data structures.
- **No UI changes** — the provider form, test-connection, and fetch-models flows work without modification because they are provider-agnostic.
