### PR TITLE
fix: resolve PythonWorker daemon startup race condition and deadlock (#321)

### DIFF
--- a/fincept-qt/src/python/PythonWorker.cpp
+++ b/fincept-qt/src/python/PythonWorker.cpp
@@ -50,6 +50,14 @@ PythonWorker::PythonWorker() {
     connect(&PythonRunner::instance(), &PythonRunner::python_ready, this, [this]() {
         ensure_started();
     });
+
+    connect(&PythonSetupManager::instance(), &PythonSetupManager::setup_complete, this, [this](bool success, const QString& /*error*/) {
+        if (success) {
+            LOG_INFO("PythonWorker", "Python/Venv setup completed successfully. Resetting restart budget and starting daemon.");
+            restart_count_ = 0;
+            ensure_started();
+        }
+    });
 }
 
 PythonWorker::~PythonWorker() {


### PR DESCRIPTION
<!--
Before opening this PR, confirm you have read .github/CONTRIBUTING.md.
PRs that do not link a scope-approved issue, or that contain auto-formatter churn,
or that are single-line wording edits without maintainer request, WILL BE CLOSED.
-->

## Scope gate (required)

- [x] This PR closes an issue that carries the `good-first-issue`, `help-wanted`, or `scope:approved` label.
- [x] I confirmed the scope with a maintainer on the issue before writing code.
- [x] This PR is from a **topic branch** (not `main` on my fork).
- [x] This PR makes **one logical change**. It does not bundle unrelated fixes.
- [x] I did **not** run Black / autopep8 / isort / clang-format / Prettier on files I did not otherwise modify.
- [x] Diff is minimal — no reformatting of surrounding lines that are unrelated to the change.

Linked issue (required — use `Closes #NNN` or `Fixes #NNN`):

Closes #321

## What does this PR do?
This PR resolves a startup race condition deadlock on the Markets and other data-driven panels where quotes, sparklines, and charts stay permanently in a "loading" / "No signal" state. 

It connects `PythonWorker` to `PythonSetupManager`'s successful completion signal. When first-run virtual environment setup completes successfully, the worker resets its retry budget and cleanly triggers `ensure_started()` to boot the yfinance daemon script.

## Type of change

- [x] Bug fix
- [ ] New feature / screen
- [ ] Performance improvement
- [ ] Refactoring (with linked issue)
- [ ] Documentation (see CONTRIBUTING — docs-only PRs allowed only for genuine errors)
- [ ] Build / config change

## Changes made
- `fincept-qt/src/python/PythonWorker.cpp`: Connected `PythonSetupManager::setup_complete` to a lambda in the constructor that resets `restart_count_` to `0` and launches the process upon success.

## How to test

1. Delete or move the `%LOCALAPPDATA%\com.fincept.terminal\venv-numpy2` directory to simulate a fresh launch/first-time setup.
2. Start the application. The first-time Setup screen will appear, showing the UV progress bootstrap.
3. Open the Markets screen. Observe that quote updates are in a loading state.
4. Once the setup completes, verify that the `PythonWorker` daemon is instantly launched and handshakes. All quotes and sparklines load successfully on the Markets screen, transitioning from loading to active data with no manual intervention.

## Architecture / code-quality checklist

- [x] Builds without errors on my target platform (Windows MSVC 2022 / Ninja)
- [x] UI thread is never blocked (no `waitForFinished()` on main thread) — see CLAUDE.md P1
- [x] Timers start/stop in `showEvent()` / `hideEvent()` — see P3
- [x] No raw `QProcess` for Python — used `PythonRunner::instance().run()` — see P4
- [x] No `print()` in Python scripts — used `logger.info` / `logger.warning` — see P14
- [x] No sensitive data (API keys, credentials) committed
- [x] DataHub rules (D1–D5) respected if touching data flow
- [x] Tested manually on: Windows

## Screenshots / logs
Logs confirming successful daemon resolution and handshake in under 4 seconds after venv is ready:
```text
[2026-05-29 10:45:31.898+02:00] [INFO] [Python] Using UV-managed venv-numpy2: C:/Users/Marcello/AppData/Local/com.fincept.terminal/venv-numpy2/Scripts/python.exe
[2026-05-29 10:45:32.031+02:00] [INFO] [PythonWorker] Launching daemon: C:/Users/Marcello/AppData/Local/com.fincept.terminal/venv-numpy2/Scripts/python.exe E:/PROGETTI/PROGRAMMAZIONE/PULL REQUEST/FinceptTerminal/fincept-qt/scripts/yfinance_data.py --daemon
[2026-05-29 10:45:35.786+02:00] [INFO] [PythonWorker] Daemon ready (pid=19380)
