### PR TITLE
fix: Bug3 news empty-feeds hang + Bug4 AngelOne depth &&->|| decoder

### DIFF
--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -564,6 +564,12 @@ FetchContent_Declare(
     GIT_SHALLOW    TRUE
     UPDATE_DISCONNECTED TRUE
 )
+set(ADS_VERSION "4.5.0" CACHE STRING "" FORCE)   # skip git_describe() in qtads CMakeLists
+# qtads src/CMakeLists.txt does include(Versioning) unconditionally but only adds
+# cmake/modules to CMAKE_MODULE_PATH inside the if(NOT ADS_VERSION) branch.
+# Pre-set the path so the include succeeds regardless of which branch ran.
+# The _deps layout is stable: FetchContent always unpacks to <binary_dir>/_deps/<name_lower>-src.
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}/_deps/qtads-src/cmake/modules")
 FetchContent_MakeAvailable(QtADS)
 # ADS target name is version-stamped: qtadvanceddocking-qt6
 # Disable unity build — ADS uses anonymous namespaces internally

--- a/fincept-qt/src/services/news/NewsService.cpp
+++ b/fincept-qt/src/services/news/NewsService.cpp
@@ -99,6 +99,14 @@ void NewsService::fetch_all_news(bool force, ArticlesCallback cb) {
     auto feeds = default_feeds();
     feed_count_ = feeds.size();
 
+    if (feeds.isEmpty()) {
+        LOG_WARN("NewsService", "No enabled feeds — returning empty result");
+        cb(true, {});
+        emit articles_updated({});
+        publish_articles_to_hub({});
+        return;
+    }
+
     // Shared state for collecting results from parallel requests
     struct FetchState {
         QMutex mutex;
@@ -250,6 +258,14 @@ void NewsService::fetch_all_news_progressive(bool force, ArticlesCallback final_
     auto feeds = default_feeds();
     feed_count_ = feeds.size();
     const int total = feeds.size();
+
+    if (feeds.isEmpty()) {
+        LOG_WARN("NewsService", "No enabled feeds — returning empty result");
+        final_cb(true, {});
+        emit articles_partial({}, 0, 0);
+        publish_articles_to_hub({});
+        return;
+    }
 
     struct FetchState {
         QMutex mutex;

--- a/fincept-qt/src/trading/websocket/AngelOneWebSocket.cpp
+++ b/fincept-qt/src/trading/websocket/AngelOneWebSocket.cpp
@@ -385,7 +385,9 @@ AoTick AngelOneWebSocket::parse_tick(const QByteArray& data) const {
     // Each entry: flag(u16,2) qty(i64,8) price(i64,8) orders(u16,2)
     // flag==0 → buy, flag!=0 → sell
     int buy_idx = 0, sell_idx = 0;
-    for (int i = 0; i < 10 && buy_idx < 5 && sell_idx < 5; ++i) {
+    // Continue while EITHER side still needs levels. && exits as soon as one
+    // side fills (buys arrive first), dropping the opposite side of the book.
+    for (int i = 0; i < 10 && (buy_idx < 5 || sell_idx < 5); ++i) {
         const uchar* entry = buf + 147 + i * 20;
         quint16 flag = read_u16_le(entry);
         qint64 qty = read_i64_le(entry + 2);


### PR DESCRIPTION
## Summary

Fixed two verified bugs across the News Service and AngelOne WebSocket subsystems, along with a build-system reliability issue affecting qtads integration.

The first bug caused the News screen to remain indefinitely stuck on **"Loading"** when all RSS feeds were disabled by the user. Since the callback was never invoked, the UI had no mechanism to recover and required a restart.

The second bug caused the AngelOne best-5 order book decoder to silently discard the entire ask side of every SnapQuote tick due to an incorrect logical operator in the depth parsing loop.

Additionally, resolved a pre-existing CMake reconfiguration failure in the qtads FetchContent dependency that was preventing successful incremental builds and rebuilds.

## Changes Made

### 1. Added empty-feed early return handling in `fetch_all_news()`

When `default_feeds()` returns an empty list, the method now immediately:

```cpp
cb(true, {});
articles_updated({});
```

and publishes an empty result through the hub before the callback is moved into `FetchState`.

This ensures callers always receive a valid completion callback even when no feeds are configured.

### 2. Added matching safeguard in `fetch_all_news_progressive()`

Implemented the same empty-feed handling for progressive news loading by immediately invoking:

```cpp
final_cb(true, {});
articles_partial({}, 0, 0);
```

This guarantees progressive-mode consumers receive a clean completion response instead of waiting indefinitely.

### 3. Fixed AngelOne best-5 depth decoding logic

In `parse_tick()`, corrected the order book parsing loop condition from:

```cpp
buy_idx < 5 && sell_idx < 5
```

to:

```cpp
buy_idx < 5 || sell_idx < 5
```

The previous implementation terminated as soon as the buy side reached five entries. Since buy levels arrive first in the packet, all sell-side depth entries remained unread, leaving `tick.asks` permanently empty.

### 4. Fixed qtads CMake reconfiguration failure

Updated `CMakeLists.txt` to improve FetchContent compatibility:

* Set `ADS_VERSION=4.5.0` to bypass the failing `git_describe()` invocation that returns `-128-NOTFOUND` inside FetchContent clones.
* Pre-appended the `cmake/modules` directory to `CMAKE_MODULE_PATH`.
* Ensured the unconditional:

```cmake
include(Versioning)
```

inside `qtads/src/CMakeLists.txt` resolves correctly during reconfiguration.

## User Impact

* News screen now immediately displays an empty state when all RSS feeds are disabled instead of hanging indefinitely on **"Loading"**.
* AngelOne SnapQuote processing now correctly decodes and populates both bid and ask depth levels for every tick.
* Incremental builds and CMake reconfiguration workflows complete successfully without qtads version-detection failures.
* Improved application stability and recovery behavior when optional data sources are intentionally disabled.

## Testing Performed

* Disabled all RSS feeds in Feed Manager and triggered a news refresh.

  * Verified the UI immediately displayed the empty state.
  * Confirmed no loading hang or restart requirement.

* Traced AngelOne SnapQuote packets using a buys-first depth layout.

  * Verified all 10 depth entries (5 bid + 5 ask) were parsed correctly.
  * Confirmed both `tick.bids` and `tick.asks` are populated.

* Performed a clean rebuild using:

```bash
cmake --build --preset win-release
```

after forcing a full CMake reconfiguration.

* Configuration completed successfully.
* All 282 targets compiled and linked successfully.
* `FinceptTerminal.exe` generated with exit code `0`.
* No new warnings introduced in modified files.

## Files Modified

* `fincept-qt/src/services/news/NewsService.cpp`
* `fincept-qt/src/trading/websocket/AngelOneWebSocket.cpp`
* `fincept-qt/CMakeLists.txt`
