### PR TITLE
fix compiling error for linux 64 bit

### DIFF
--- a/fincept-qt/src/algo_engine/DeploymentRunner.cpp
+++ b/fincept-qt/src/algo_engine/DeploymentRunner.cpp
@@ -342,7 +342,7 @@ void DeploymentRunner::persist_trade(const AlgoTradeRecord& trade) {
     q.addBindValue(trade.pnl);
     q.addBindValue(trade.reason);
     q.addBindValue(trade.broker_order_id);
-    q.addBindValue(trade.latency_ms);
+    q.addBindValue(QVariant::fromValue(trade.latency_ms));
     if (!q.exec())
         LOG_ERROR("AlgoEngine", QString("Failed to persist trade: %1").arg(q.lastError().text()));
 }


### PR DESCRIPTION
Closes #332 
latency_ms type is int64_t
  Linux 64 bit platform it is long
  windows 64 bit platform it is long long
addBindValue takes "const QVariant&", QVariant doesn't have a constructor with long so it caused overload resolution failed, although there is a constructor with long long which will work on windows and Linux 32 bit

The fix is to use QVariant member function fromValue