### PR TITLE
Fix Windows source build by using Qt bundled zlib

### DIFF
--- a/fincept-qt/CMakeLists.txt
+++ b/fincept-qt/CMakeLists.txt
@@ -3087,9 +3087,13 @@ message(STATUS "OpenSSL found: ${OPENSSL_VERSION} — include: ${OPENSSL_INCLUDE
 # zlib: gzip (Upstox master) + zip (Shoonya symbol masters) decompression.
 # See trading/instruments/InstrumentDecompress.cpp. System zlib on macOS/Linux,
 # Qt-bundled on Windows.
-find_package(ZLIB REQUIRED)
-message(STATUS "ZLIB found: ${ZLIB_VERSION_STRING}")
-
+if(WIN32)
+    find_package(Qt6ZlibPrivate REQUIRED)
+    message(STATUS "Using Qt bundled Zlib")
+else()
+    find_package(ZLIB REQUIRED)
+    message(STATUS "ZLIB found: ${ZLIB_VERSION_STRING}")
+endif()
 # ── macOS: make Qt's openssl TLS plugin discoverable ─────────────────────────
 # Qt's libqopensslbackend.dylib only searches /usr/local/lib, /opt/local/lib,
 # /sw/lib, /usr/lib and Qt's own lib dir for libssl/libcrypto. Homebrew on
@@ -3143,10 +3147,13 @@ target_link_libraries(FinceptTerminal PRIVATE
     qtadvanceddocking-qt6
     OpenSSL::SSL
     OpenSSL::Crypto
-    ZLIB::ZLIB
     fincept_ed25519
 )
-
+if(WIN32)
+    target_link_libraries(FinceptTerminal PRIVATE Qt6::ZlibPrivate)
+else()
+    target_link_libraries(FinceptTerminal PRIVATE ZLIB::ZLIB)
+endif()
 # SecureStorage no longer needs platform-specific credential frameworks —
 # it's pure SQLite + AES-256-GCM (OpenSSL) on every platform. See
 # storage/secure/SecureStorage.cpp.


### PR DESCRIPTION
## Problem

Building the project from source on Windows failed during the configuration step with the following error:

```text
Could NOT find ZLIB (missing: ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
```

Although Qt 6.8.3 already ships with its own bundled zlib, the Windows build configuration was still expecting a separate system-installed ZLIB package.

## Solution

Updated the Windows build configuration to use Qt's bundled zlib (`Qt6ZlibPrivate`) instead of requiring an external ZLIB installation.

The existing `ZLIB::ZLIB` dependency remains unchanged for non-Windows platforms.

## Validation

* Configuration completes successfully on Windows
* Full project builds without errors
* `FinceptTerminal.exe` launches and runs correctly
* Existing 4.1.0 packaged builds continue to work as expected
