### PR TITLE
fix(http): add 30-second default transfer timeout to HttpClient

### DIFF
--- a/fincept-qt/src/network/http/HttpClient.cpp
+++ b/fincept-qt/src/network/http/HttpClient.cpp
@@ -22,6 +22,7 @@ QNetworkRequest HttpClient::build_request(const QString& url) const {
     QNetworkRequest req{qurl};
     req.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
     req.setHeader(QNetworkRequest::UserAgentHeader, "FinceptTerminal/4.0");
+    req.setTransferTimeout(30000);
 
     // Only attach auth on same-host requests — third-party absolute URLs (Slack/Discord/webhooks)
     // share this singleton and must NOT receive X-API-Key / X-Session-Token.


### PR DESCRIPTION
Add req.setTransferTimeout(30000) to HttpClient::build_request().
All auth, session, and cloud API calls using the shared singleton
were previously unbounded a network hang would freeze the UI until
the OS-level socket timeout (minutes). 30 s is a safe default; callers
that need longer can override per-request.

Fixes: HttpClient::build_request had no setTransferTimeout call.