### PR TITLE
Fix typo: recieve -> receive in OptionChainProviderAlgorithm.py

### DIFF
--- a/fincept-qt/scripts/strategies/OptionChainProviderAlgorithm.py
+++ b/fincept-qt/scripts/strategies/OptionChainProviderAlgorithm.py
@@ -12,7 +12,7 @@
 from AlgorithmImports import *
 
 ### <summary>
-### Demonstration of the Option Chain Provider -- a much faster mechanism for manually specifying the option contracts you'd like to recieve
+### Demonstration of the Option Chain Provider -- a much faster mechanism for manually specifying the option contracts you'd like to receive
 ### data for and manually subscribing to them.
 ### </summary>
 ### <meta name="tag" content="strategy example" />


### PR DESCRIPTION
## Summary

Fixed a typo in `fincept-qt/scripts/strategies/OptionChainProviderAlgorithm.py` where "recieve" was misspelled as "receive" in a comment.

Closes #323

## Changes
- Corrected "recieve" to "receive" in line 15 of `fincept-qt/scripts/strategies/OptionChainProviderAlgorithm.py`

## Testing
- The change is a single-word spelling correction in a comment only. No functional code was modified.