### PR TITLE
Fix macOS/Linux link failure: only define Z_PREFIX on Windows

### DIFF
--- a/fincept-qt/src/trading/instruments/InstrumentDecompress.cpp
+++ b/fincept-qt/src/trading/instruments/InstrumentDecompress.cpp
@@ -10,7 +10,9 @@
 // shadows it on the include path (e.g. a PostgreSQL install whose include dir
 // precedes QtZlib), the unprefixed symbols won't link. Define it ourselves so
 // inflate() → z_inflate() regardless of which standard zlib.h is picked up.
-#ifndef Z_PREFIX
+// On macOS/Linux we link the system zlib (ZLIB::ZLIB in CMakeLists.txt),
+// whose symbols are unprefixed — so only define Z_PREFIX on Windows.
+#if defined(_WIN32) && !defined(Z_PREFIX)
 #    define Z_PREFIX
 #endif
 #include <zlib.h>


### PR DESCRIPTION
Closes #358

## Problem

Building `macos-release` from source on macOS (Qt 6.8.3 via aqtinstall, per `setup.sh`) fails at the final link:

```
Undefined symbols for architecture x86_64:
  "_z_inflate", referenced from:
      fincept::trading::decompress::(anonymous namespace)::inflate_stream(QByteArray const&, int) in InstrumentDecompress.cpp.o
  "_z_inflateEnd", ...
  "_z_inflateInit2_", ...
ld: symbol(s) not found for architecture x86_64
```

## Cause

`src/trading/instruments/InstrumentDecompress.cpp` unconditionally defines `Z_PREFIX` before `#include <zlib.h>`, renaming all zlib calls to `z_`-prefixed symbols. That matches `Qt6::ZlibPrivate` — but CMakeLists.txt only links that on Windows. On macOS/Linux the target links the **system** zlib (`ZLIB::ZLIB`), whose exported symbols are unprefixed, so the prefixed references can't resolve (unless the local Qt build happens to re-export the bundled-zlib symbols from QtCore, which the official Qt 6.8.3 macOS binaries do not).

## Fix

Define `Z_PREFIX` only under `_WIN32`, mirroring the existing platform branch in CMakeLists.txt (`WIN32 → Qt6ZlibPrivate`, `else → ZLIB::ZLIB`). One file, three lines.

Verified: full `macos-release` build now links and the app runs (tested on macOS 26.5 / Intel x86_64 / Apple Clang 17 / Qt 6.8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
