### PR TITLE
fix(auth): add username field to RegisterScreen (#318)

### DIFF
--- a/fincept-qt/src/screens/auth/RegisterScreen.cpp
+++ b/fincept-qt/src/screens/auth/RegisterScreen.cpp
@@ -135,8 +135,8 @@ RegisterScreen::RegisterScreen(QWidget* parent) : QWidget(parent) {
     });
     connect(&auth, &auth::AuthManager::otp_verified, this, [this]() {
         verify_btn_->setEnabled(true);
-        for (QLineEdit* w :
-             {first_name_, last_name_, email_, phone_, country_code_, password_, confirm_pw_, otp_input_}) {
+        for (QLineEdit* w : {first_name_, last_name_, username_, email_, phone_, country_code_, password_,
+                             confirm_pw_, otp_input_}) {
             if (w)
                 w->clear();
         }
@@ -248,6 +248,10 @@ void RegisterScreen::build_form_page() {
     add_field(last_name_lbl_, last_name_, ln_col);
     nrl->addLayout(ln_col);
     vl->addWidget(name_row);
+
+    // Username is required by POST /user/register; do not invent it from the
+    // name fields (that hid the control and caused silent collisions — #318).
+    add_field(username_lbl_, username_, vl);
 
     add_field(email_lbl_, email_, vl);
 
@@ -436,6 +440,8 @@ void RegisterScreen::retranslateUi() {
         first_name_lbl_->setText(tr("FIRST NAME"));
     if (last_name_lbl_)
         last_name_lbl_->setText(tr("LAST NAME"));
+    if (username_lbl_)
+        username_lbl_->setText(tr("USERNAME"));
     if (email_lbl_)
         email_lbl_->setText(tr("EMAIL"));
     if (code_lbl_)
@@ -451,6 +457,8 @@ void RegisterScreen::retranslateUi() {
         first_name_->setPlaceholderText(tr("First"));
     if (last_name_)
         last_name_->setPlaceholderText(tr("Last"));
+    if (username_)
+        username_->setPlaceholderText(tr("3-50 chars, letters/numbers/_"));
     if (email_)
         email_->setPlaceholderText(tr("user@domain.com"));
     if (country_code_)
@@ -501,14 +509,27 @@ void RegisterScreen::on_register() {
 
     QString fn = first_name_->text().trimmed();
     QString ln = last_name_->text().trimmed();
+    QString username = auth::sanitize_input(username_->text()).toLower();
     QString em = email_->text().trimmed();
     QString ph = phone_->text().trimmed();
     QString cc = country_code_->text().trimmed();
     QString pw = password_->text();
     QString cpw = confirm_pw_->text();
 
-    if (fn.isEmpty() || ln.isEmpty() || em.isEmpty() || ph.isEmpty() || pw.isEmpty() || cpw.isEmpty()) {
+    if (fn.isEmpty() || ln.isEmpty() || username.isEmpty() || em.isEmpty() || ph.isEmpty() || pw.isEmpty() ||
+        cpw.isEmpty()) {
         error_label_->setText(tr("All fields are required"));
+        error_label_->show();
+        return;
+    }
+    if (username.length() < 3 || username.length() > 50) {
+        error_label_->setText(tr("Username must be 3-50 characters"));
+        error_label_->show();
+        return;
+    }
+    // Keep usernames URL/API-safe; spaces from names were a common failure mode.
+    if (!QRegularExpression(QStringLiteral("^[a-z0-9_]+$")).match(username).hasMatch()) {
+        error_label_->setText(tr("Username may only contain letters, numbers, and underscores"));
         error_label_->show();
         return;
     }
@@ -539,13 +560,6 @@ void RegisterScreen::on_register() {
         return;
     }
 
-    QString username = auth::sanitize_input(fn + ln).toLower();
-    if (username.length() < 3 || username.length() > 50) {
-        error_label_->setText(tr("Username must be 3-50 characters"));
-        error_label_->show();
-        return;
-    }
-
     register_btn_->setEnabled(false);
     register_btn_->setText(tr("  CREATING...  "));
     auth::AuthManager::instance().signup(username, em, pw, ph, {}, cc);
@@ -565,9 +579,7 @@ void RegisterScreen::on_verify_otp() {
 }
 
 void RegisterScreen::on_resend_otp() {
-    QString fn = first_name_->text().trimmed();
-    QString ln = last_name_->text().trimmed();
-    QString username = auth::sanitize_input(fn + ln).toLower();
+    QString username = auth::sanitize_input(username_->text()).toLower();
     QString cc = country_code_->text().trimmed();
     if (!cc.isEmpty() && !cc.startsWith('+'))
         cc = '+' + cc;

--- a/fincept-qt/src/screens/auth/RegisterScreen.h
+++ b/fincept-qt/src/screens/auth/RegisterScreen.h
@@ -32,6 +32,7 @@ class RegisterScreen : public QWidget {
     QLabel* form_title_ = nullptr;
     QLabel* first_name_lbl_ = nullptr;
     QLabel* last_name_lbl_ = nullptr;
+    QLabel* username_lbl_ = nullptr;
     QLabel* email_lbl_ = nullptr;
     QLabel* code_lbl_ = nullptr;
     QLabel* phone_lbl_ = nullptr;
@@ -40,6 +41,7 @@ class RegisterScreen : public QWidget {
 
     QLineEdit* first_name_ = nullptr;
     QLineEdit* last_name_ = nullptr;
+    QLineEdit* username_ = nullptr;
     QLineEdit* email_ = nullptr;
     QLineEdit* phone_ = nullptr;
     QLineEdit* country_code_ = nullptr;


### PR DESCRIPTION
## Summary

Closes #318

The Windows (and all-platform) signup form never exposed a **USERNAME** field, even though `POST /user/register` always requires one via `RegisterRequest::username`. The UI silently invented a username by concatenating first + last name:

```cpp
QString username = auth::sanitize_input(fn + ln).toLower();
```

That caused several user-visible failures matching the report:

| Failure mode | Why it happens |
|---|---|
| Signup fails for common names | `John` + `Smith` → `johnsmith` collides with an existing account |
| Confusing client-side error | `"Username must be 3-50 characters"` appears with **no username field on screen** |
| Spaces / invalid characters | Names like `Mary Jane` produce usernames with spaces that APIs reject |
| Opaque identity | Users never choose or know the username stored for their account |

This PR adds an explicit username input and wires it through the existing `AuthManager::signup()` / OTP-resend path. No AuthManager or AuthApi signature changes.

### Scope note for maintainers

Per [`.github/CONTRIBUTING.md`](https://github.com/Fincept-Corporation/FinceptTerminal/blob/main/.github/CONTRIBUTING.md), PRs must link an issue labeled `good-first-issue`, `help-wanted`, or `scope:approved`. Issue #318 currently has `type:bug` + `status:triage` only.

**Please add `good-first-issue` or `scope:approved` to #318 (or to this PR) so the scope gate clears.** This is intentionally minimal and newcomer-sized: two files, one screen, one logical change.

---

## Changes

### `RegisterScreen.h`
- Add `username_lbl_` / `username_` members alongside the other form fields.

### `RegisterScreen.cpp`
- Insert a **USERNAME** field after the first/last name row (before email).
- Localize label + placeholder via `retranslateUi()` (`tr("USERNAME")`, `tr("3-50 chars, letters/numbers/_")`).
- `on_register()`:
  - Require username in the “all fields required” check.
  - Validate length 3–50.
  - Restrict to `[a-z0-9_]` after sanitize/lowercase (prevents the old space-from-name failure mode).
  - Pass the user-entered username to `AuthManager::signup(...)`.
- `on_resend_otp()` uses the same username field (no more name concatenation).
- Clear `username_` on successful OTP verification with the other fields.

First/last name fields are **kept** for UX continuity (they are still not sent to the API today — that is pre-existing and out of scope).

---

## User-visible effect

Before: signup form = First / Last / Email / Phone / Password — username invented invisibly.  
After: signup form includes **USERNAME**; the value the user types is what gets registered.

---

## Test plan

- [ ] Build `fincept-qt` on your platform (`cmake --build --preset <os>-release` or local equivalent).
- [ ] Open **Create Account** from the auth stack.
- [ ] Confirm a **USERNAME** field appears between name and email, with localized label/placeholder.
- [ ] Submit with empty username → `"All fields are required"`.
- [ ] Submit username shorter than 3 chars → length error.
- [ ] Submit username with spaces or symbols (e.g. `john smith`, `john@x`) → charset error.
- [ ] Submit a valid unique username + other valid fields → proceeds to OTP page (or surfaces the real API error if the backend is down — unrelated to this UI fix).
- [ ] On OTP page, **Resend** still uses the typed username (not first+last).
- [ ] After successful OTP (when API is healthy), form fields including username are cleared.
- [ ] Switch UI language and confirm USERNAME label/placeholder retranslate.

### What I could / could not verify locally

I did **not** run a full Qt 6.8.3 app build or hit `api.fincept.in` end-to-end in this environment (upstream API TLS issues are tracked separately, e.g. #352). The change is UI-only against an already-correct `signup(username, ...)` API surface; logic was reviewed against `AuthTypes.h` / `AuthManager::signup` / `AuthApi` register error paths.

---

## Out of scope (intentionally)

- Backend / Cloudflare signup outages (HTTP 530, TLS on `api.fincept.in`).
- Sending first/last name to the register API (API schema does not accept them today).
- Async “username available” availability check.
- Translation `.ts` / `.qm` updates for the new strings ( Linguist will pick them up on the next `lupdate` pass; English `tr()` sources are in place).

Made with [Cursor](https://cursor.com)