### PR TITLE
Fix asset search dropdown overlap, clipping, and vertical scrollbar

### DIFF
--- a/fincept-qt/src/screens/portfolio/PortfolioDialogs.cpp
+++ b/fincept-qt/src/screens/portfolio/PortfolioDialogs.cpp
@@ -5,6 +5,7 @@
 #include "services/markets/MarketSearchService.h"
 #include "ui/theme/Theme.h"
 
+#include <QApplication>
 #include <QDate>
 #include <QDateEdit>
 #include <QEvent>
@@ -306,24 +307,38 @@ AddAssetDialog::AddAssetDialog(QWidget* parent) : QDialog(parent) {
 
     layout->addLayout(btn_layout);
 
-    // ── Search dropdown (floats over the dialog, parented to this) ────────────
     search_frame_ = new QFrame(this);
+    search_frame_->setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint);
+    search_frame_->setAttribute(Qt::WA_ShowWithoutActivating);
     search_frame_->setObjectName("assetSearchFrame");
     search_frame_->setStyleSheet(
         QString("QFrame#assetSearchFrame { background:%1; border:1px solid %2; border-top:none; }")
             .arg(ui::colors::BG_SURFACE(), ui::colors::BORDER_MED()));
     search_frame_->hide();
 
+    // Hide dropdown when app loses focus
+    connect(qApp, &QApplication::focusChanged, this, [this](QWidget*, QWidget* now) {
+        if (search_frame_->isVisible()) {
+            if (!now || (now != symbol_edit_ && !search_frame_->isAncestorOf(now) && now != search_list_)) {
+                search_frame_->hide();
+            }
+        }
+    });
+
     auto* frame_layout = new QVBoxLayout(search_frame_);
     frame_layout->setContentsMargins(0, 0, 0, 0);
     frame_layout->setSpacing(0);
 
     search_list_ = new QListWidget(search_frame_);
-    search_list_->setStyleSheet(QString("QListWidget { background:transparent; border:none; outline:none; }"
+    search_list_->setStyleSheet(QString("QListWidget { background:%1; border:none; outline:none; }"
                                         "QListWidget::item { padding:0; border:none; background:transparent; }"
-                                        "QListWidget::item:selected { background:%1; border-left:3px solid %2; }")
-                                    .arg(ui::colors::BORDER_DIM(), ui::colors::AMBER()));
+                                        "QListWidget::item:selected { background:%2; border-left:3px solid %3; }"
+                                        "QScrollBar:vertical { background:%1; width:6px; margin:0; }"
+                                        "QScrollBar::handle:vertical { background:%2; border-radius:3px; min-height:15px; }"
+                                        "QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height:0; }")
+                                    .arg(ui::colors::BG_SURFACE(), ui::colors::BORDER_DIM(), ui::colors::AMBER()));
     search_list_->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    search_list_->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     search_list_->setCursor(Qt::PointingHandCursor);
     frame_layout->addWidget(search_list_);
 
@@ -384,7 +399,7 @@ void AddAssetDialog::show_results(const QList<fincept::services::MarketSearchSer
     if (results.isEmpty()) {
         auto* item = new QListWidgetItem(search_list_);
         item->setFlags(item->flags() & ~Qt::ItemIsSelectable);
-        auto* row = new QWidget(this);
+        auto* row = new QWidget(search_list_);
         row->setStyleSheet("background:transparent;");
         auto* rl = new QHBoxLayout(row);
         rl->setContentsMargins(10, 6, 10, 6);
@@ -423,7 +438,7 @@ void AddAssetDialog::show_results(const QList<fincept::services::MarketSearchSer
         auto* item = new QListWidgetItem(search_list_);
         item->setData(Qt::UserRole, yf_sym);
 
-        auto* row = new QWidget(this);
+        auto* row = new QWidget(search_list_);
         row->setStyleSheet("background:transparent;");
         auto* hl = new QHBoxLayout(row);
         hl->setContentsMargins(10, 4, 10, 4);
@@ -483,9 +498,9 @@ void AddAssetDialog::select_result(const QString& sym) {
 
 void AddAssetDialog::position_dropdown() {
     // Place the dropdown directly below the symbol_edit_ row
-    const QPoint origin = symbol_edit_->mapTo(this, QPoint(0, symbol_edit_->height()));
+    const QPoint origin = symbol_edit_->mapToGlobal(QPoint(0, symbol_edit_->height()));
     const int w = symbol_edit_->width() + 60; // a bit wider to show exchange column
-    const int rows = std::min(search_list_->count(), kAssetSearchLimit);
+    const int rows = std::min(search_list_->count(), 6);
     const int h = rows * 30 + 2;
     search_frame_->setGeometry(origin.x(), origin.y(), w, h);
 }
@@ -524,6 +539,13 @@ void AddAssetDialog::changeEvent(QEvent* event) {
     if (event->type() == QEvent::LanguageChange)
         retranslateUi();
     QDialog::changeEvent(event);
+}
+
+void AddAssetDialog::moveEvent(QMoveEvent* event) {
+    QDialog::moveEvent(event);
+    if (search_frame_ && search_frame_->isVisible()) {
+        position_dropdown();
+    }
 }
 
 void AddAssetDialog::retranslateUi() {

--- a/fincept-qt/src/screens/portfolio/PortfolioDialogs.h
+++ b/fincept-qt/src/screens/portfolio/PortfolioDialogs.h
@@ -14,6 +14,7 @@
 #include <QListWidget>
 #include <QPushButton>
 #include <QRadioButton>
+#include <QMoveEvent>
 #include <QString>
 #include <QTimer>
 
@@ -80,6 +81,7 @@ class AddAssetDialog : public QDialog {
   protected:
     bool eventFilter(QObject* obj, QEvent* event) override;
     void changeEvent(QEvent* event) override;
+    void moveEvent(QMoveEvent* event) override;
 
   private:
     void retranslateUi();


### PR DESCRIPTION
<!--
Before opening this PR, confirm you have read .github/CONTRIBUTING.md.
PRs that do not link a scope-approved issue, or that contain auto-formatter churn,
or that are single-line wording edits without maintainer request, WILL BE CLOSED.
-->

## Scope gate (required)

- [ ] This PR closes an issue that carries the `good-first-issue`, `help-wanted`, or `scope:approved` label.
- [ ] I confirmed the scope with a maintainer on the issue before writing code.
- [x] This PR is from a **topic branch** (not `main` on my fork).
- [x] This PR makes **one logical change**. It does not bundle unrelated fixes.
- [x] I did **not** run Black / autopep8 / isort / clang-format / Prettier on files I did not otherwise modify.
- [x] Diff is minimal — no reformatting of surrounding lines that are unrelated to the change.

Fixes #361

## What does this PR do?
Fixes the "Add Asset" dialog's ticker search suggestions dropdown rendering transparently, bleeding background elements, and getting clipped by the dialog's boundaries. It also caps the visible list height at 6 items and displays a custom scrollbar for overflow items.

## Type of change

- [x] Bug fix
- [ ] New feature / screen
- [ ] Performance improvement
- [ ] Refactoring (with linked issue)
- [ ] Documentation (see CONTRIBUTING — docs-only PRs allowed only for genuine errors)
- [ ] Build / config change

## Changes made
- **`fincept-qt/src/screens/portfolio/PortfolioDialogs.h`**: Included `<QMoveEvent>` and declared the `moveEvent()` override.
- **`fincept-qt/src/screens/portfolio/PortfolioDialogs.cpp`**:
  - Configured `search_frame_` as a top-level `Qt::Tool` window to bypass dialog boundary clipping and layout rendering collisions.
  - Instantiated and set a solid dark background on `search_list_`.
  - Parented cell row widgets directly to `search_list_` for a correct widget hierarchy.
  - Implemented focus-loss auto-dismissal using `qApp->focusChanged`.
  - Capped the dropdown height to 6 items in `position_dropdown()` using global coordinates.
  - Implemented `moveEvent()` to update coordinates dynamically if the dialog is dragged on screen.

## How to test

1. Open the "Add Asset" dialog by clicking "OPEN BUY ORDER" on the Portfolio screen.
2. Type a ticker query (e.g. `AA`) into the **Symbol** field to trigger the suggestion list.
3. Verify that the dropdown has a solid background (no bleed-through of labels) and is not clipped on the right or bottom edges of the dialog.
4. Verify that when suggestions exceed 6 items, it caps the height and displays a custom scrollbar.
5. Drag the dialog window around and verify that the suggestions dropdown window moves with it.

## Architecture / code-quality checklist

- [x] Builds without errors on my target platform (Windows)
- [x] UI thread is never blocked (no `waitForFinished()` on main thread) — see CLAUDE.md P1
- [x] Timers start/stop in `showEvent()` / `hideEvent()` — see P3
- [x] No raw `QProcess` for Python — used `PythonRunner::instance().run()` — see P4
- [x] No `print()` in Python scripts — used `logger.info` / `logger.warning` — see P14
- [x] No sensitive data (API keys, credentials) committed
- [x] DataHub rules (D1–D5) respected if touching data flow
- [x] Tested manually on: Windows

## Screenshots / logs
<!-- For UI changes include before/after. For bug fixes include the log line that proves the fix. -->

### Before:
<img width="454" height="337" alt="image" src="https://github.com/user-attachments/assets/0e991167-0417-4127-93ab-e785145bde98" />

### After:
<img width="460" height="321" alt="image" src="https://github.com/user-attachments/assets/2fb9dd7e-081e-4f4d-a223-5199f9b71b99" />
