### PR TITLE
feat: Add sticky Markdown copy button to Portfolio AI Analysis

### DIFF
--- a/fincept-qt/src/screens/portfolio/PortfolioInsightsPanel.cpp
+++ b/fincept-qt/src/screens/portfolio/PortfolioInsightsPanel.cpp
@@ -8,8 +8,15 @@
 #include "ui/markdown/MarkdownRenderer.h"
 #include "ui/theme/Theme.h"
 
+#include <QApplication>
+#include <QClipboard>
 #include <QComboBox>
+#include <QIcon>
+#include <QPainter>
+#include <QPainterPath>
+#include <QPixmap>
 #include <QDateTime>
+#include <QTimer>
 #include <QEvent>
 #include <QHBoxLayout>
 #include <QJsonArray>
@@ -31,6 +38,43 @@ namespace {
 
 QString fmt_now() {
     return QDateTime::currentDateTime().toString("HH:mm:ss");
+}
+
+QIcon make_copy_icon() {
+    auto draw_pm = [](const QColor& color) {
+        QPixmap pm(16, 16);
+        pm.fill(Qt::transparent);
+        QPainter p(&pm);
+        p.setRenderHint(QPainter::Antialiasing);
+        p.setPen(QPen(color, 1.25));
+        p.setBrush(Qt::NoBrush);
+        p.drawRect(2, 2, 8, 10);
+        
+        p.setBrush(QColor(15, 15, 15));
+        p.drawRect(5, 5, 8, 10);
+        return pm;
+    };
+
+    QIcon icon;
+    icon.addPixmap(draw_pm(QColor(ui::colors::TEXT_SECONDARY())), QIcon::Normal);
+    icon.addPixmap(draw_pm(QColor(ui::colors::AMBER())), QIcon::Active);
+    return icon;
+}
+
+QIcon make_check_icon() {
+    QPixmap pm(16, 16);
+    pm.fill(Qt::transparent);
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing);
+    p.setPen(QPen(QColor(ui::colors::POSITIVE()), 1.5, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+    
+    QPainterPath path;
+    path.moveTo(3, 8);
+    path.lineTo(6.5, 11.5);
+    path.lineTo(13, 4);
+    p.drawPath(path);
+    
+    return QIcon(pm);
 }
 
 // SettingsRepository category under which AI/agent results are persisted.
@@ -332,6 +376,42 @@ QWidget* PortfolioInsightsPanel::build_ai_page() {
                                        "  font-size:12px; }")
                                    .arg(bg, text1));
     lay->addWidget(ai_content_, 1);
+
+    // Copy Button overlay on the QTextBrowser itself (not viewport, so it remains sticky)
+    ai_copy_btn_ = new QPushButton(ai_content_);
+    ai_copy_btn_->setCursor(Qt::PointingHandCursor);
+    ai_copy_btn_->setToolTip(tr("Copy entire analysis to clipboard"));
+    ai_copy_btn_->setFixedSize(26, 26);
+    ai_copy_btn_->setIcon(make_copy_icon());
+    ai_copy_btn_->setIconSize(QSize(14, 14));
+
+    QString btn_ss = QString(
+        "QPushButton { background: %1; border: 1px solid %2; border-radius: 4px; }"
+        "QPushButton:hover { background: %3; border-color: %4; }"
+    ).arg("rgba(15, 15, 15, 0.8)", ui::colors::BORDER_MED(),
+          "rgba(30, 30, 30, 0.95)", ui::colors::AMBER());
+    ai_copy_btn_->setStyleSheet(btn_ss);
+    ai_copy_btn_->hide(); // Hidden initially, shown only when rendering successful results
+
+    connect(ai_copy_btn_, &QPushButton::clicked, this, [this, btn_ss]() {
+        QString text = ai_cache_.value(ai_type_);
+        if (text.isEmpty()) {
+            text = ai_content_->toPlainText();
+        }
+        QGuiApplication::clipboard()->setText(text);
+        ai_copy_btn_->setIcon(make_check_icon());
+        ai_copy_btn_->setStyleSheet(QString(
+            "QPushButton { background: %1; border: 1px solid %2; border-radius: 4px; }"
+        ).arg("rgba(15, 15, 15, 0.8)", ui::colors::POSITIVE()));
+
+        QTimer::singleShot(1500, ai_copy_btn_, [this, btn_ss]() {
+            ai_copy_btn_->setIcon(make_copy_icon());
+            ai_copy_btn_->setStyleSheet(btn_ss);
+        });
+    });
+
+    ai_content_->viewport()->installEventFilter(this);
+
     render_empty(ai_content_, tr("Select an analysis type and press RUN.\n\n"
                                  "FULL — broad review of holdings and allocation.\n"
                                  "RISK — concentration, correlation, downside scenarios.\n"
@@ -753,6 +833,15 @@ void PortfolioInsightsPanel::render_result(QTextBrowser* target, const QString& 
     }
     target->setHtml(ui::MarkdownRenderer::render(markdown));
     target->verticalScrollBar()->setValue(0);
+
+    if (target == ai_content_ && ai_copy_btn_) {
+        ai_copy_btn_->show();
+        if (ai_content_->viewport()) {
+            int x = ai_content_->viewport()->x() + ai_content_->viewport()->width() - ai_copy_btn_->width() - 12;
+            int y = ai_content_->viewport()->y() + 12;
+            ai_copy_btn_->move(x, y);
+        }
+    }
 }
 
 void PortfolioInsightsPanel::render_error(QTextBrowser* target, const QString& message) {
@@ -764,12 +853,27 @@ void PortfolioInsightsPanel::render_error(QTextBrowser* target, const QString& m
                             "<div style='color:%2; font-weight:700; letter-spacing:1px; margin-bottom:8px;'>"
                             "⚠ %4</div>%3</div>")
                         .arg(ui::colors::TEXT_PRIMARY(), ui::colors::NEGATIVE(), safe, tr("ERROR")));
+
+    if (target == ai_content_ && ai_copy_btn_) {
+        ai_copy_btn_->hide();
+    }
 }
 
 void PortfolioInsightsPanel::changeEvent(QEvent* event) {
     if (event->type() == QEvent::LanguageChange)
         retranslateUi();
     QWidget::changeEvent(event);
+}
+
+bool PortfolioInsightsPanel::eventFilter(QObject* obj, QEvent* event) {
+    if (ai_content_ && obj == ai_content_->viewport() && event->type() == QEvent::Resize) {
+        if (ai_copy_btn_) {
+            int x = ai_content_->viewport()->x() + ai_content_->viewport()->width() - ai_copy_btn_->width() - 12;
+            int y = ai_content_->viewport()->y() + 12;
+            ai_copy_btn_->move(x, y);
+        }
+    }
+    return QWidget::eventFilter(obj, event);
 }
 
 void PortfolioInsightsPanel::retranslate_ai_run_label() {
@@ -836,6 +940,10 @@ void PortfolioInsightsPanel::render_empty(QTextBrowser* target, const QString& h
     safe.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\n", "<br>");
     target->setHtml(QString("<div style='color:%1; font-size:11px; line-height:1.7; padding-top:8px;'>%2</div>")
                         .arg(ui::colors::TEXT_TERTIARY(), safe));
+
+    if (target == ai_content_ && ai_copy_btn_) {
+        ai_copy_btn_->hide();
+    }
 }
 
 } // namespace fincept::screens

--- a/fincept-qt/src/screens/portfolio/PortfolioInsightsPanel.h
+++ b/fincept-qt/src/screens/portfolio/PortfolioInsightsPanel.h
@@ -39,6 +39,7 @@ class PortfolioInsightsPanel : public QWidget {
     void keyPressEvent(QKeyEvent* e) override;
     void showEvent(QShowEvent* e) override;
     void changeEvent(QEvent* event) override;
+    bool eventFilter(QObject* obj, QEvent* event) override;
 
   private:
     void build_ui();
@@ -81,6 +82,7 @@ class PortfolioInsightsPanel : public QWidget {
     QPushButton* ai_run_ = nullptr;
     QLabel* ai_meta_ = nullptr;
     QTextBrowser* ai_content_ = nullptr;
+    QPushButton* ai_copy_btn_ = nullptr;
 
     // Agent page
     QComboBox* agent_cb_ = nullptr;


### PR DESCRIPTION
<!--
Before opening this PR, confirm you have read .github/CONTRIBUTING.md.
-->

## Scope gate (required)

- [ ] This PR closes an issue that carries the `good-first-issue`, `help-wanted`, or `scope:approved` label.
- [ ] I confirmed the scope with a maintainer on the issue before writing code.
- [x] This PR is from a **topic branch** (not `main` on my fork).
- [x] This PR makes **one logical change**. It does not bundle unrelated fixes.
- [x] I did **not** run Black / autopep8 / isort / clang-format / Prettier on files I did not otherwise modify.
- [x] Diff is minimal — no reformatting of surrounding lines that are unrelated to the change.

## What does this PR do?
Adds a sticky, custom-rendered floating copy button to the top-right corner of the Portfolio -> AI Analysis output. The button remains fixed at the top-right when scrolling, shifts to prevent overlapping with the vertical scrollbar, copies the raw Markdown (`.md`) text format (preserving headers, bold tags, lists, and tables), and shows a green success checkmark on click.

## Type of change

- [ ] Bug fix
- [x] New feature / screen
- [ ] Performance improvement
- [ ] Refactoring (with linked issue)
- [ ] Documentation
- [ ] Build / config change

## Changes made
- **`fincept-qt/src/screens/portfolio/PortfolioInsightsPanel.h`**: Added `eventFilter()` override and `ai_copy_btn_` pointer.
- **`fincept-qt/src/screens/portfolio/PortfolioInsightsPanel.cpp`**:
  - Implemented custom overlapping-sheet copy icons and checkmark icons using `QPainter`.
  - Instantiated `ai_copy_btn_` overlay parented to `ai_content_` (to keep it sticky).
  - Used `eventFilter` on the viewport resize event to dynamically align the button to the left of the scrollbar (leaving a 12px gap).
  - Wired clipboard copy handling to pull raw Markdown from `ai_cache_` (with plain text fallback) and update icons on success.
  - Hidden button when output is empty or contains an error.

## How to test

1. Open the **Portfolio** screen and click **AI Analysis** on the right panel.
2. Select any analysis type and click **RUN**.
3. Verify that the floating copy button (clipboard icon) appears in the top-right of the box once the analysis loads.
4. Scroll through the analysis and verify that the button remains fixed at the top-right and does not overlap with the scrollbar.
5. Hover over the button to see it highlight to amber, and click it to copy the raw Markdown formatted text to your clipboard.
6. Verify that it flashes a green checkmark `✓` for `1500ms` on success.

## Architecture / code-quality checklist

- [x] Builds without errors on my target platform (Windows)
- [x] UI thread is never blocked (no `waitForFinished()` on main thread) — see CLAUDE.md P1
- [x] Timers start/stop in `showEvent()` / `hideEvent()` — see P3
- [x] No sensitive data committed
- [x] Tested manually on: Windows

## Screenshots / logs

### Copied State:
<img width="564" height="331" alt="image" src="https://github.com/user-attachments/assets/2657a47a-86dc-44e8-9fbb-0067d287b418" />