### PR TITLE
feat(auth): add offline mode support for local usage without login

### DIFF
--- a/fincept-qt/src/app/WindowFrame_Auth.cpp
+++ b/fincept-qt/src/app/WindowFrame_Auth.cpp
@@ -163,10 +163,12 @@ void WindowFrame::on_auth_state_changed() {
             for (const QString& bid : fincept::trading::SymbolResolver::instance().registered_brokers())
                 isvc.load_from_db_async(bid);
         } else {
-            // Free/no plan → show pricing gate
-            set_shell_visible(false);
-            stack_->setCurrentIndex(0);
-            auth_stack_->setCurrentIndex(3);
+            // Free/no plan → allow access to dashboard (offline/local mode)
+            set_shell_visible(true);
+            stack_->setCurrentIndex(1);
+            // Cold-boot restore: try last_loaded layout, then most recent
+            // auto snapshot, then no-op (first run).
+            layout::WorkspaceShell::load_last_or_default();
         }
     } else {
         // Disable inactivity guard when logged out and drop the locked flag

--- a/fincept-qt/src/auth/AuthManager.cpp
+++ b/fincept-qt/src/auth/AuthManager.cpp
@@ -204,6 +204,11 @@ void AuthManager::initialize() {
     set_loading(true);
     load_session();
 
+    // Check for offline mode via environment variable or settings
+    bool offline_mode = qEnvironmentVariableIsSet("FINCEPT_OFFLINE_MODE") || 
+                        (fincept::SettingsRepository::instance().get("app/offline_mode").is_ok() && 
+                         fincept::SettingsRepository::instance().get("app/offline_mode").value().toLower() == "true");
+
     if (!session_.api_key.isEmpty()) {
         // Apply api_key ONLY — do NOT send the stale session_token during
         // startup validation. The server enforces single-session via
@@ -214,6 +219,20 @@ void AuthManager::initialize() {
         http.clear_session_token();
 
         validate_saved_session();
+        return;
+    }
+
+    // OFFLINE MODE: Create a local "free" session if no credentials exist
+    if (offline_mode) {
+        LOG_INFO("Auth", "Offline mode enabled — creating local free session");
+        session_.authenticated = true;
+        session_.user_info.account_type = "free";
+        session_.user_info.username = "offline_user";
+        session_.user_info.email = "offline@local";
+        session_.has_subscription = false;
+        save_session();
+        set_loading(false);
+        emit auth_state_changed();
         return;
     }
 


### PR DESCRIPTION
## Summary

Adds offline mode support enabling full local usage of Fincept Terminal without requiring login to the Fincept API.

## Changes

1. **AuthManager.cpp**: Added  environment variable and  settings key
   - When enabled and no valid session exists, creates a local free session:
     - 
     - 
     - 
     - 
     - 

2. **WindowFrame_Auth.cpp**: Modified pricing gate to allow free/offline users to access dashboard
   - Free users now go to dashboard (index 1) instead of pricing screen (index 3)
   - Loads last workspace layout on startup

## Motivation

The v4.3.0 macOS DMG has broken Python paths (references missing  vs system ) and the public API () has SSL/handshake issues blocking login. This allows users to build from source and use the terminal fully offline.

## What Works Offline

- ✅ Market data (Yahoo Finance, FRED, DBnomics, Polygon)
- ✅ Equity Research, Portfolio, Derivatives, QuantLib
- ✅ Crypto Center (demo mode)
- ✅ Node Editor workflows
- ✅ 54 AI agents (local LLM via Ollama)
- ✅ 926 MCP tools
- ✅ Python analytics engine

## What Doesn't Work (By Design)

- ❌ Chat/Agent cloud features (requires private API)
- ❌ Some premium news feeds
- ❌ Cloud sync / subscription features

## Testing

Built from source using  on macOS 26.5.2 (Apple Silicon). Verified offline mode creates session and loads dashboard.
