### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ Questions: [support@fincept.in](mailto:support@fincept.in) · [Terms](https://fi
 ### **Your Thinking is the Only Limit. The Data Isn't.**
 
 <div align="center">
-<a href="https://star-history.com/#Fincept-Corporation/FinceptTerminal&Date">
+<a href="https://star-history.dera.page/#Fincept-Corporation/FinceptTerminal&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
  </picture>
 </a>
 </div>


### PR DESCRIPTION
The Star History Chart shown in the README is currently broken because of GitHub stargazer API restrictions. This change updates the chart to use a working alternative service so the chart renders correctly again.

The chart now loads from star-history.dera.page, which does not require any API token and serves the chart from the same domain.