### PR TITLE
fix(dashboard): ticker tape renders point change as a percentage

### DIFF
--- a/fincept-qt/src/screens/dashboard/DashboardScreen.cpp
+++ b/fincept-qt/src/screens/dashboard/DashboardScreen.cpp
@@ -310,7 +310,7 @@ void DashboardScreen::rebuild_ticker_from_cache() {
         if (!ticker_cache_.contains(sym))
             continue;
         const auto& q = ticker_cache_.value(sym);
-        entries.append({q.symbol, q.price, q.change});
+        entries.append({q.symbol, q.price, q.change_pct});
     }
     if (!entries.isEmpty())
         ticker_bar_->set_data(entries);

--- a/fincept-qt/src/screens/dashboard/TickerBar.cpp
+++ b/fincept-qt/src/screens/dashboard/TickerBar.cpp
@@ -167,8 +167,8 @@ void TickerBar::rebuild_entry_cache() {
     total_width_ = 0;
     for (auto& e : entries_) {
         e.price_text = QString::number(e.price, 'f', 2);
-        e.change_text = QString("%1%2%").arg(e.change >= 0 ? "+" : "").arg(e.change, 0, 'f', 2);
-        e.change_col = QColor(ui::change_color(e.change));
+        e.change_text = QString("%1%2%").arg(e.change_pct >= 0 ? "+" : "").arg(e.change_pct, 0, 'f', 2);
+        e.change_col = QColor(ui::change_color(e.change_pct));
 
         e.symbol_width = ticker_fm_.horizontalAdvance(e.symbol);
         e.price_width = ticker_fm_.horizontalAdvance(e.price_text);

--- a/fincept-qt/src/screens/dashboard/TickerBar.h
+++ b/fincept-qt/src/screens/dashboard/TickerBar.h
@@ -21,13 +21,16 @@ class TickerBar : public QWidget {
   public:
     explicit TickerBar(QWidget* parent = nullptr);
 
-    /// Callers fill only symbol/price/change; everything below is derived once
-    /// in set_data(). paintEvent runs 20×/s over every entry × every pass, so
-    /// it must not format strings or measure text — see rebuild_entry_cache().
+    /// Callers fill only symbol/price/change_pct; everything below is derived
+    /// once in set_data(). paintEvent runs 20×/s over every entry × every pass,
+    /// so it must not format strings or measure text — see rebuild_entry_cache().
     struct Entry {
         QString symbol{};
         double price = 0;
-        double change = 0;
+        /// Percent change, NOT the absolute price change. rebuild_entry_cache()
+        /// renders this with a trailing '%', so passing a point delta here
+        /// prints e.g. "-90.88%" for a 0.35% move. Feed QuoteData::change_pct.
+        double change_pct = 0;
 
         // ── Derived (do not set from outside) ──
         // The `{}` are load-bearing: callers brace-init only the first three


### PR DESCRIPTION
## The bug

The dashboard ticker tape formats its change value with a trailing `%`, but is fed the **absolute** price change instead of the percent change. The Global Indices widget sitting directly beneath it shows the same instruments correctly, so the two disagree on screen.

Observed on v4.4.1 (macOS arm64), default dashboard layout:

| Instrument | Ticker tape says | Global Indices widget says | Actual |
|---|---|---|---|
| `^GDAXI` | `-90.88%` | `-90.88` / `-0.35%` | −0.35% |
| `^N225` | `-2134.30%` | `-2134.30` / `-3.16%` | −3.16% |
| `^FTSE` | `+12.53%` | `+12.53` / `+0.12%` | +0.12% |

The obviously-absurd readings (`-2134.30%`) are harmless. The hazard is the small ones: **`^FTSE +12.53%` looks entirely plausible** and is off by a factor of ~100.

## Root cause

`TickerBar::rebuild_entry_cache()` renders `Entry::change` with a `%` suffix:

```cpp
// TickerBar.cpp:170
e.change_text = QString("%1%2%").arg(e.change >= 0 ? "+" : "").arg(e.change, 0, 'f', 2);
```

But `DashboardScreen::rebuild_ticker_from_cache()` fills that field from `QuoteData::change` (points) rather than `QuoteData::change_pct`, which sits next to it in the same struct and is already populated by the feed:

```cpp
// DashboardScreen.cpp:314
entries.append({q.symbol, q.price, q.change});
```

## The fix

1. Pass `q.change_pct` at the call site.
2. Rename `Entry::change` → `Entry::change_pct`, with a comment naming the failure mode. The defect was invited by a field named `change` that is rendered as a percentage; the rename makes the contract self-documenting.

`ScreenerScreen.cpp:329` already formats `QuoteData::change_pct` with this exact pattern — the ticker bar now matches that existing reference implementation.

## Scope

- `TickerBar::Entry` has exactly **one** construction site repo-wide, so the rename is fully contained.
- `CryptoTickerBar` and `EquityTickerBar` are separate classes and were already correct — untouched.
- Type is unchanged (`double` → `double`); `ui::change_color()` keys off sign, which is identical for both fields, so colouring behaviour is unaffected.

## Testing

Reviewed and statically verified; **not compile-tested** — I don't have the pinned Qt 6.8.3 toolchain set up locally. The change is three lines of like-for-like type substitution plus a rename, but a maintainer build is worth a moment before merge.