### PR TITLE
Fixed broken star history in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,11 @@ Questions: [support@fincept.in](mailto:support@fincept.in) · [Terms](https://fi
 ### **Your Thinking is the Only Limit. The Data Isn't.**
 
 <div align="center">
-<a href="https://star-history.com/#Fincept-Corporation/FinceptTerminal&Date">
+<a href="https://star-history.dera.page/#Fincept-Corporation/FinceptTerminal&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=Fincept-Corporation/FinceptTerminal&type=Date" />
  </picture>
 </a>
 </div>


### PR DESCRIPTION
## Description

Fixes the broken Star History chart displayed in the project's `README.md`.

The current Star History chart is not loading/displaying correctly, which prevents visitors from viewing the project's GitHub star growth directly from the README.

### What changed

- Updated the Star History reference in `README.md`.
- Replaced the broken/outdated chart URL with a working one.
- Kept the change limited to the README and did not modify unrelated content.

### User-visible effect

The Star History chart should now load correctly when viewing the README on GitHub, allowing users to see the project's star history as intended.

### Testing

- Verified the updated Star History URL.
- Verified that the README renders the Star History chart correctly.

Closes #373 