### PR TITLE
fix(setup): resolve openssl@3 prefix via brew so setup.sh works on Intel Macs

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -208,8 +208,13 @@ echo "[6/7] Configuring (preset: $PRESET)..."
 # Override the preset's default CMAKE_PREFIX_PATH with the one we just set,
 # so the build picks up the aqtinstall location rather than ~/Qt/6.8.3/...
 EXTRA_ARGS=""
-if [ "$PLATFORM" = "macos" ] && [ -d "/opt/homebrew/opt/openssl@3" ]; then
-    EXTRA_ARGS="-DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3"
+if [ "$PLATFORM" = "macos" ]; then
+    # Resolve the openssl@3 prefix from brew itself rather than hardcoding the
+    # Apple Silicon path — Intel Macs use /usr/local, not /opt/homebrew.
+    OPENSSL_PREFIX="$(brew --prefix openssl@3 2>/dev/null || true)"
+    if [ -n "$OPENSSL_PREFIX" ] && [ -d "$OPENSSL_PREFIX" ]; then
+        EXTRA_ARGS="-DOPENSSL_ROOT_DIR=$OPENSSL_PREFIX"
+    fi
 fi
 
 cmake --preset "$PRESET" -DCMAKE_PREFIX_PATH="$QT_PREFIX" $EXTRA_ARGS \


### PR DESCRIPTION
## Problem

`setup.sh` only sets `OPENSSL_ROOT_DIR` when `/opt/homebrew/opt/openssl@3` exists:

```bash
if [ "$PLATFORM" = "macos" ] && [ -d "/opt/homebrew/opt/openssl@3" ]; then
    EXTRA_ARGS="-DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl@3"
fi
```

`/opt/homebrew` is the Apple Silicon prefix. On Intel Macs Homebrew installs under `/usr/local`, so the test fails, `EXTRA_ARGS` stays empty, and CMake is configured with no OpenSSL root.

## Impact on Intel Macs

**1. Configure fails.** `fincept-qt/CMakeLists.txt` calls `find_package(OpenSSL REQUIRED)`. macOS ships no OpenSSL development headers, so with no root to search this is a hard stop — `./setup.sh` cannot complete on an Intel Mac as written.

**2. A quieter TLS problem.** Even given a working OpenSSL, the guard below is skipped because it is conditioned on the same variable:

```cmake
if(APPLE AND OPENSSL_ROOT_DIR)
    # symlink libssl/libcrypto into Qt's lib dir
```

The comment on that block explains the stakes: without the symlinks Qt's openssl TLS plugin fails to register and Qt falls back to the deprecated SecureTransport backend, "which double-frees in SSLWrite during QWebSocket close and crashes the crypto tab." So the hardcoded path also silently disarms the workaround for that crash.

## Fix

Ask Homebrew for the prefix rather than hardcoding one:

```bash
OPENSSL_PREFIX="$(brew --prefix openssl@3 2>/dev/null || true)"
```

This is correct on both architectures and additionally honours a non-standard `HOMEBREW_PREFIX`. When `openssl@3` is not installed, `brew --prefix` fails, `EXTRA_ARGS` stays empty, and behaviour is exactly as before — so this is a no-op wherever the current code already worked.

## Verification

Built from a clean clone on:

- macOS 15.7.9, Intel x86_64
- Apple Clang 17.0.0
- Qt 6.8.3 (aqtinstall, `clang_64`), CMake 3.27.7, Ninja 1.11.1
- Homebrew `openssl@3` 3.6.3 at `/usr/local/opt/openssl@3`

Results:

- Configure succeeds — `Found OpenSSL: /usr/local/opt/openssl@3/lib/libcrypto.dylib (found version "3.6.3")`
- All four symlinks created in Qt's lib dir (`libssl.dylib`, `libssl.3.dylib`, `libcrypto.dylib`, `libcrypto.3.dylib`)
- Build completes: 758/758 targets, 0 errors
- App logs `TLS backend: openssl (available: securetransport, openssl, cert-only)` at startup, confirming the openssl plugin registered rather than falling back to SecureTransport

Without this change the same clone fails at the configure step.
